### PR TITLE
Add support for setting multiple outgouing IPs

### DIFF
--- a/config.php
+++ b/config.php
@@ -13,6 +13,17 @@
   /**********|| features ||***************/
   $config['feature']['browserExtensions']=true; // show links for install browser extensions? true or false
   
+  /**********|| Multiple IPs ||***************/
+  $config['multipleIPs']=false; // enable multiple IPs support to bypass Youtube IP limit? true or false
+  $config['IPs'] = [
+	  //'xxx.xxx.xxx.xxx',
+	  //'xxx.xxx.xxx.xxx',
+	  //'xxx.xxx.xxx.xxx',
+	  //'xxx.xxx.xxx.xxx',
+	  //'xxx.xxx.xxx.xxx',
+	  // add as many ips as you want (they must be available in the server conf (ex: /etc/network/interfaces fro ubuntu/debian)
+  ];
+  
   /**********|| Other ||***************/
   // Set your default timezone
   // use this link: http://php.net/manual/en/timezones.php

--- a/config.php
+++ b/config.php
@@ -14,6 +14,66 @@
   $config['feature']['browserExtensions']=true; // show links for install browser extensions? true or false
   
   /**********|| Multiple IPs ||***************/
+  # You can enable this option if you are having problems with youtube IP limit / IP ban.
+  # This option will work only if the IP you add are available for the server.
+  # That means you have to buy some additionnal public IPs and assign these new static IPs to the server.
+  # This should work only if you have a dedicated server...
+  #
+  #
+  # Example of adding additional IPs to Ubuntu server 14.04 LTS 
+  # !!!! Be very careful, you may block yourself !!!!
+  # !!!! If you are connecting to your server remotly by ssh. You would do this only if you know what you do !!!!
+  # !!!! This is only an example with a specific dedicated server (ovh.net) !!!!
+  #
+  # For this example, the main IP on the server is 123.456.789.001
+  # We want to add additionnal IPs 789.456.123.001 and 789.456.123.002
+  #
+  # Edit /etc/network/interfaces and put something like this:
+  #
+  # # The loopback network interface
+  # auto lo
+  # iface lo inet loopback
+  #
+  # # The Main server IP: 
+  # auto eth0
+  # iface eth0 inet static
+  #     address 123.456.789.001
+  #     netmask 255.255.255.0
+  #     network 123.456.789.0
+  #     broadcast 123.456.789.255
+  #     gateway 123.456.789.254
+  #
+  # # Additionnal IP: 789.456.123.001
+  # auto eth0:0
+  # iface eth0:0 inet static
+  #     address 789.456.123.001
+  #     netmask 255.255.255.255
+  #     broadcast 789.456.123.001
+  #     gateway 123.456.789.254
+  #
+  # # Additionnal IP: 789.456.123.002
+  # auto eth0:1
+  # iface eth0:0 inet static
+  #     address 789.456.123.002
+  #     netmask 255.255.255.255
+  #     broadcast 789.456.123.002
+  #     gateway 123.456.789.254
+  #
+  # # Additionnal IP xxx.xxx.xxx.xxx
+  # auto eth0:2
+  # iface eth0:2 inet static
+  # (...)
+  #
+  # and so on for each IP you want to add....
+  #
+  #
+  # Reboot your server
+  # If you are having trouble and cannot connect anymore over ssh to your server,
+  # that means your new network configuration has errors...
+  # So be very careful before applying your configuration.
+  # Try it first on a local dev server before messing up with your pro server.
+  # 
+  # 
   $config['multipleIPs']=false; // enable multiple IPs support to bypass Youtube IP limit? true or false
   $config['IPs'] = [
 	  //'xxx.xxx.xxx.xxx',

--- a/curl.php
+++ b/curl.php
@@ -1,13 +1,28 @@
 <?php
 /*
+ * If multipleIPs mode is enabled, select randomly one IP from
+ * the config IPs array and put it in $outgoing_ip variable.
+ */
+if ($config['multipleIPs'] === true) {
+	// randomly select an ip from the $config['IPs'] array
+	$outgoing_ip = $config['IPs'][mt_rand(0, count($config['IPs']) - 1)];
+}
+
+/*
  * function to get via cUrl 
  * From lastRSS 0.9.1 by Vojtech Semecky, webmaster @ webdot . cz
  * See      http://lastrss.webdot.cz/
  */
  
 function curlGet($URL) {
+	global $config; // get global $config to know if $config['multipleIPs'] is true
     $ch = curl_init();
     $timeout = 3;
+    if ($config['multipleIPs'] === true) {
+	    // if $config['multipleIPs'] is true set outgoing ip to $outgoing_ip
+	    global $outgoing_ip;
+	    curl_setopt($ch, CURLOPT_INTERFACE, $outgoing_ip);
+	}
     curl_setopt( $ch , CURLOPT_URL , $URL );
     curl_setopt( $ch , CURLOPT_RETURNTRANSFER , 1 );
     curl_setopt( $ch , CURLOPT_CONNECTTIMEOUT , $timeout );
@@ -22,7 +37,12 @@ function curlGet($URL) {
  * function to use cUrl to get the headers of the file 
  */ 
 function get_location($url) {
+	global $config;
 	$my_ch = curl_init();
+	if ($config['multipleIPs'] === true) {
+	    global $outgoing_ip;
+	    curl_setopt($my_ch, CURLOPT_INTERFACE, $outgoing_ip);
+	}
 	curl_setopt($my_ch, CURLOPT_URL,$url);
 	curl_setopt($my_ch, CURLOPT_HEADER,         true);
 	curl_setopt($my_ch, CURLOPT_NOBODY,         true);
@@ -38,7 +58,12 @@ function get_location($url) {
 }
 
 function get_size($url) {
+	global $config;
 	$my_ch = curl_init();
+	if ($config['multipleIPs'] === true) {
+	    global $outgoing_ip;
+	    curl_setopt($my_ch, CURLOPT_INTERFACE, $outgoing_ip);
+	}
 	curl_setopt($my_ch, CURLOPT_URL,$url);
 	curl_setopt($my_ch, CURLOPT_HEADER,         true);
 	curl_setopt($my_ch, CURLOPT_NOBODY,         true);

--- a/getvideo.php
+++ b/getvideo.php
@@ -170,6 +170,11 @@ if(isset($url_encoded_fmt_stream_map)) {
 	/* Now get the url_encoded_fmt_stream_map, and explode on comma */
 	$my_formats_array = explode(',',$url_encoded_fmt_stream_map);
 	if($debug) {
+		if($config['multipleIPs'] === true) {
+			echo '<pre>Outgoing IP: ';
+			print_r($outgoing_ip);
+			echo '</pre>';
+		}
 		echo '<pre>';
 		print_r($my_formats_array);
 		echo '</pre>';


### PR DESCRIPTION
The new option is disabled by default, so the majority of users will not be disturbed.
If someone wants to use this new option, I have written some comments in config.php
Maybe the server configuration is a little too complicated to understand, but it is mandatory if the user wants to use multiple IPs.
@jeckman if you don't have a server with multiple IPs to test this new option, I can setup a new online version on mine that will permit you to see it in action. Let me know.
I have tested it with 16 IP, it is working.
Maybe one thing to add is detecting if an IP is banned with the curl request, and use another IP that is not banned instead (to detect http error from youtube).