### PR TITLE
RegEx matches URLs starting with http(s)

### DIFF
--- a/getvideo.php
+++ b/getvideo.php
@@ -33,7 +33,7 @@ function is_chrome(){
 
 if(isset($_REQUEST['videoid'])) {
 	$my_id = $_REQUEST['videoid'];
-	if( preg_match('/^https:\/\/w{3}?.youtube.com\//', $my_id) ){
+	if( preg_match('/^(https?:\/\/)?(w{3}\.)?youtube.com\//', $my_id) ){
 		$url   = parse_url($my_id);
 		$my_id = NULL;
 		if( is_array($url) && count($url)>0 && isset($url['query']) && !empty($url['query']) ){
@@ -55,10 +55,10 @@ if(isset($_REQUEST['videoid'])) {
 			echo '<p>Invalid url</p>';
 			exit;
 		}
-	}elseif( preg_match('/^https?:\/\/youtu.be/', $my_id) ) {
+	}elseif( preg_match('/^(https?:\/\/)?youtu.be/', $my_id) ) {
 		$url   = parse_url($my_id);
 		$my_id = NULL;
-		$my_id = preg_replace('/^\//', '', $url['path']);
+		$my_id = preg_replace('/^(youtu\.be)?\//', '', $url['path']);
 	}
 } else {
 	echo '<p>No video id passed in</p>';

--- a/index.php
+++ b/index.php
@@ -45,8 +45,14 @@
 <body>
 	<form class="form-download" method="get" id="download" action="getvideo.php">
 		<h1 class="form-download-heading">Youtube Downloader</h1>
-		<input type="text" name="videoid" id="videoid" size="40" placeholder="VideoID" />
+		<input type="text" name="videoid" id="videoid" size="40" placeholder="YouTube Link or VideoID" />
 		<input class="btn btn-primary" type="submit" name="type" id="type" value="Download" />
+		<p>Valid inputs are YouTube links or VideoIDs:</p>
+		<ul>
+			<li>youtube.com/watch?v=<b>aBCdEFGhIJk</b></li>
+			<li><b>youtube.com/watch?v=...</b></li>
+			<li><b>youtu.be/...</b></li>
+		</ul>
 		<p>Put in just the ID bit, the part after v=.</p>
 		<p>Example: http://www.youtube.com/watch?v=<b>Fw-BM-Mqgeg</b></p>
 

--- a/index.php
+++ b/index.php
@@ -53,8 +53,6 @@
 			<li><b>youtube.com/watch?v=...</b></li>
 			<li><b>youtu.be/...</b></li>
 		</ul>
-		<p>Put in just the ID bit, the part after v=.</p>
-		<p>Example: http://www.youtube.com/watch?v=<b>Fw-BM-Mqgeg</b></p>
 
     <!-- @TODO: Prepend the base URI -->
     <?PHP


### PR DESCRIPTION
Just a few modifications in order to allow processing urls starting with http(s) or without http(s) (in case of '_youtu.be/..._').

Cross checked against those inputs (which should be valid now):
- {videoID}
- youtube.com/watch?v=...
- http://youtube.com/watch?v=...
- https://youtube.com/watch?v=...
- http://www.youtube.com/watch?v=...
- https://www.youtube.com/watch?v=...
- youtu.be/...
- http://youtu.be/...
- https://youtu.be/...