### PR TITLE
Updated function createStreamMapFromVideoInfo()

### DIFF
--- a/src/YoutubeDownloader.php
+++ b/src/YoutubeDownloader.php
@@ -210,7 +210,14 @@ class YoutubeDownloader
 
 	public static function createStreamMapFromVideoInfo(array $video_info)
 	{
-		return [explode(',', $video_info['url_encoded_fmt_stream_map']), explode(',', $video_info['adaptive_fmts'])];
+    if (isset($video_info['url_encoded_fmt_stream_map']) && isset($video_info['adaptive_fmts'])) {
+      return [
+        explode(',', $video_info['url_encoded_fmt_stream_map']),
+        explode(',', $video_info['adaptive_fmts'])
+      ];
+    }
+
+    return [];
 	}
 
 	public static function parseStreamMapToFormats(array $stream_map)


### PR DESCRIPTION
There are some errors for newly created videos on Youtube, because Youtube doesn't give some information yet.

Screenshot: https://prntscr.com/f9bp7w
URL with shortage info: https://www.youtube.com/watch?v=pGmV7i48vs8