### PR TITLE
Add method VideoInfo::getVideoId()

### DIFF
--- a/src/VideoInfo.php
+++ b/src/VideoInfo.php
@@ -147,6 +147,7 @@ class VideoInfo
 	 * Set the necessary keys
 	 */
 	private $allowed_keys = [
+		'video_id',
 		'status',
 		'reason',
 		'thumbnail_url',
@@ -174,6 +175,16 @@ class VideoInfo
 				$this->data[$key] = null;
 			}
 		}
+	}
+
+	/**
+	 * Get the video_id
+	 *
+	 * @return string
+	 */
+	public function getVideoId()
+	{
+		return $this->data['video_id'];
 	}
 
 	/**

--- a/tests/Unit/VideoInfoTest.php
+++ b/tests/Unit/VideoInfoTest.php
@@ -15,6 +15,16 @@ class VideoInfoTest extends \YoutubeDownloader\Tests\Fixture\TestCase
 	}
 
 	/**
+	 * @test getVideoId()
+	 */
+	public function getVideoId()
+	{
+		$video_info = VideoInfo::createFromString('video_id=123abc');
+
+		$this->assertSame('123abc', $video_info->getVideoId());
+	}
+
+	/**
 	 * @test getStatus()
 	 */
 	public function getStatus()


### PR DESCRIPTION
This new method `VideoInfo::getVideoId()` returns the `video_id` from a `VideoInfo` class.

refs #210.