### PR TITLE
Refactoring and new decipher config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- new configuration 'enable_youtube_decipher_signature' for automatically decipher a YouTube signature. Default is set to false.
+- `Application\ControllerAbstract::responseWithErrorMessage()` to echo an error message and exit
+- `VideoInfo::createFromStringWithConfig()` to pass a configuration while creating the VideoInfo
+- `VideoInfo::getFormats()` to get the formats for a video
+- `VideoInfo::getAdaptiveFormats()` to get the adaptive formats for a video
+
+### Deprecated
+
+- class `StreamMap` will be removed in release 0.3, use `VideoInfo::getFormats()` and `VideoInfo::getAdaptiveFormats()` instead
+- class `Stream` will be removed in release 0.3, use `Format` instead
+- method `VideoInfo::createFromString()` will be removed in release 0.3, use `VideoInfo::createFromStringWithConfig()` instead
+- method `VideoInfo::getStreamMapString()` will be removed in release 0.3, use `VideoInfo::getFormats()` instead
+- method `VideoInfo::getAdaptiveFormatsString()` will be removed in release 0.3, use `VideoInfo::getAdaptiveFormats()` instead
+
 ## [0.1] - 2017-07-19
 
 ### Added

--- a/config/default.php
+++ b/config/default.php
@@ -8,6 +8,16 @@
 
 return [
     /**
+     * Enable the YouTube signature decipher function
+     * WARNING: This downloads javascript code from a 3rd party server and interprets it!
+     * This MAY harm your server, if the 3rd party server delivers malicious code!
+     *
+     * false => decipher is disabled
+     * true => decipher is enabled
+     */
+    'enable_youtube_decipher_signature' => false,
+
+    /**
      * Thumbnail Image Configuration
      *
      * 0 => don't show thumbnail image

--- a/config/default.php
+++ b/config/default.php
@@ -8,6 +8,17 @@
 
 return [
     /**
+     * Debug mode
+     * WARNING: This outputs debug information while processing.
+     * This could leak sensitive server data to the browser.
+     * Enable only if needed.
+     *
+     * true   => debug mode on
+     * false  => debug mode off
+     */
+    'debug' => false,
+
+    /**
      * Enable the YouTube signature decipher function
      * WARNING: This downloads javascript code from a 3rd party server and interprets it!
      * This MAY harm your server, if the 3rd party server delivers malicious code!
@@ -138,15 +149,9 @@ return [
     /**
      * Set your default timezone
      *
-     * use this link: http://php.net/manual/en/timezones.php
-     */
-    'default_timezone' => 'Asia/Tehran',
-
-    /**
-     * Debug mode
+     * e.g. Asia/Tehran or America/New_York
      *
-     * true   => debug mode on
-     * false  => debug mode off
+     * more examples: http://php.net/manual/en/timezones.php
      */
-    'debug' => false,
+    'default_timezone' => 'UTC',
 ];

--- a/src/Application/ControllerAbstract.php
+++ b/src/Application/ControllerAbstract.php
@@ -42,4 +42,22 @@ abstract class ControllerAbstract implements Controller
 	{
 		return $this->app->getVersion();
 	}
+
+	/**
+	 * Echos an error and exit
+	 *
+	 * @param string $message
+	 * @return void
+	 */
+	protected function responseWithErrorMessage($message)
+	{
+		$template = $this->get('template');
+
+		echo $template->render('error.php', [
+			'app_version' => $this->getAppVersion(),
+			'error_message' => strval($message),
+		]);
+
+		exit;
+	}
 }

--- a/src/Application/DownloadController.php
+++ b/src/Application/DownloadController.php
@@ -66,12 +66,11 @@ class DownloadController extends ControllerAbstract
 
 				$video_info_url = 'https://www.youtube.com/get_video_info?&video_id=' . $url. '&asv=3&el=detailpage&hl=en_US';
 				$video_info_string = $toolkit->curlGet($video_info_url, $config);
-				$video_info = \YoutubeDownloader\VideoInfo::createFromString($video_info_string);
-				$stream_map = \YoutubeDownloader\StreamMap::createFromVideoInfo($video_info);
+				$video_info = \YoutubeDownloader\VideoInfo::createFromStringWithConfig($video_info_string, $config);
 
 				try
 				{
-					$mp3_info = $toolkit->getDownloadMP3($stream_map, $config);
+					$mp3_info = $toolkit->getDownloadMP3($video_info, $config);
 				}
 				catch (Exception $e)
 				{

--- a/src/Application/DownloadController.php
+++ b/src/Application/DownloadController.php
@@ -20,16 +20,12 @@ class DownloadController extends ControllerAbstract
 	public function execute()
 	{
 		$config = $this->get('config');
-		$template = $this->get('template');
 		$toolkit = $this->get('toolkit');
 
 		// Check download token
 		if (empty($_GET['mime']) OR empty($_GET['token']))
 		{
-			echo $template->render('error.php', [
-				'error_message' => 'Invalid download token 8{',
-			]);
-			exit();
+			$this->responseWithErrorMessage('Invalid download token 8{');
 		}
 
 		// Set operation params
@@ -44,10 +40,9 @@ class DownloadController extends ControllerAbstract
 			// prevent unauthorized download
 			if($config->get('VideoLinkMode') === "direct" and !isset($_GET['getmp3']))
 			{
-				echo $template->render('error.php', [
-					'error_message' => 'VideoLinkMode: proxy download not enabled',
-				]);
-				exit;
+				$this->responseWithErrorMessage(
+					'VideoLinkMode: proxy download not enabled'
+				);
 			}
 
 			if(
@@ -56,10 +51,7 @@ class DownloadController extends ControllerAbstract
 				and ! preg_match('@https://[^\.]+\.googlevideo.com/@', $url)
 			)
 			{
-				echo $template->render('error.php', [
-					'error_message' => 'unauthorized access (^_^)',
-				]);
-				exit;
+				$this->responseWithErrorMessage('unauthorized access (^_^)');
 			}
 
 			// check if request for mp3 download
@@ -67,10 +59,9 @@ class DownloadController extends ControllerAbstract
 			{
 				if( ! $config->get('MP3Enable') )
 				{
-					echo $template->render('error.php', [
-						'error_message' => 'Option for MP3 download is not enabled.',
-					]);
-					exit;
+					$this->responseWithErrorMessage(
+						'Option for MP3 download is not enabled.'
+					);
 				}
 
 				$video_info_url = 'https://www.youtube.com/get_video_info?&video_id=' . $url. '&asv=3&el=detailpage&hl=en_US';
@@ -91,11 +82,7 @@ class DownloadController extends ControllerAbstract
 						$message .= " " . $e->getPrevious()->getMessage();
 					}
 
-
-					echo $template->render('error.php', [
-						'error_message' => $message,
-					]);
-					exit;
+					$this->responseWithErrorMessage($message);
 				}
 
 				$url = $mp3_info['mp3'];
@@ -129,9 +116,6 @@ class DownloadController extends ControllerAbstract
 		}
 
 		// Not found
-		echo $template->render('error.php', [
-			'error_message' => 'File not found 8{',
-		]);
-		exit;
+		$this->responseWithErrorMessage('File not found 8{');
 	}
 }

--- a/src/Application/ImageController.php
+++ b/src/Application/ImageController.php
@@ -18,25 +18,18 @@ class ImageController extends ControllerAbstract
 	public function execute()
 	{
 		$config = $this->get('config');
-		$template = $this->get('template');
 		$toolkit = $this->get('toolkit');
 
 		if ( ! isset($_GET['videoid']) )
 		{
-			echo $template->render('error.php', [
-				'error_message' => 'No video id passed in',
-			]);
-			exit;
+			$this->responseWithErrorMessage('No video id passed in');
 		}
 
 		$my_id = $toolkit->validateVideoId($_GET['videoid']);
 
 		if ( $my_id === null )
 		{
-			echo $template->render('error.php', [
-				'error_message' => 'Invalid video id passed in',
-			]);
-			exit;
+			$this->responseWithErrorMessage('Invalid video id passed in');
 		}
 
 		$szName = 'default';

--- a/src/Application/ResultController.php
+++ b/src/Application/ResultController.php
@@ -23,10 +23,7 @@ class ResultController extends ControllerAbstract
 
 		if( ! isset($_GET['videoid']) )
 		{
-			echo $template->render('error.php', [
-				'error_message' => 'No video id passed in',
-			]);
-			exit;
+			$this->responseWithErrorMessage('No video id passed in');
 		}
 
 		$my_id = $_GET['videoid'];
@@ -40,10 +37,7 @@ class ResultController extends ControllerAbstract
 
 		if ( $my_id === null )
 		{
-			echo $template->render('error.php', [
-				'error_message' => 'Invalid url',
-			]);
-			exit;
+			$this->responseWithErrorMessage('Invalid url');
 		}
 
 		if (isset($_GET['type']))
@@ -70,18 +64,14 @@ class ResultController extends ControllerAbstract
 
 		if ($video_info->getStatus() == 'fail')
 		{
-			echo $template->render('error.php', [
-				'error_message' => 'Error in video ID: ' . $video_info->getErrorReason(),
-			]);
+			$message = 'Error in video ID: ' . $video_info->getErrorReason();
 
 			if ($config->get('debug'))
 			{
-				echo '<pre>';
-				var_dump($video_info);
-				echo '</pre>';
+				$message .= '<pre>' . var_dump($video_info) . '</pre>';
 			}
 
-			exit;
+			$this->responseWithErrorMessage($message);
 		}
 
 		if ( $my_type !== 'Download' )
@@ -138,6 +128,13 @@ class ResultController extends ControllerAbstract
 
 		$stream_map = \YoutubeDownloader\StreamMap::createFromVideoInfo($video_info);
 
+		if (count($stream_map->getStreams()) == 0)
+		{
+			$this->responseWithErrorMessage(
+				'No format stream map found - was the video id correct?'
+			);
+		}
+
 		if ($config->get('debug'))
 		{
 			$debug1 = '';
@@ -149,14 +146,6 @@ class ResultController extends ControllerAbstract
 
 			$template_data['show_debug1'] = true;
 			$template_data['debug1'] = var_export($stream_map, true);
-		}
-
-		if (count($stream_map->getStreams()) == 0)
-		{
-			echo $template->render('error.php', [
-				'error_message' => 'No format stream map found - was the video id correct?',
-			]);
-			exit;
 		}
 
 		/* create an array of available download formats */

--- a/src/Config.php
+++ b/src/Config.php
@@ -32,6 +32,7 @@ class Config
 	private $data = [];
 
 	private $allowed_keys = [
+		'enable_youtube_decipher_signature',
 		'ThumbnailImageMode',
 		'VideoLinkMode',
 		'MP3Enable',

--- a/src/Config.php
+++ b/src/Config.php
@@ -12,7 +12,7 @@ class Config
 	 *
 	 * @param string $default full path to default config php file
 	 * @param string $custom full path to custom config php file
-	 * @return StreamMap
+	 * @return Config
 	 */
 	public static function createFromFiles($default, $custom = null)
 	{

--- a/src/Format.php
+++ b/src/Format.php
@@ -2,18 +2,10 @@
 
 namespace YoutubeDownloader;
 
-@trigger_error(
-	'`Stream` is deprecated since version 0.2, to be removed in 0.3. '.
-	'Use `Format` instead',
-	E_USER_DEPRECATED
-);
-
 /**
- * Stream
- *
- * @deprecated since version 0.2, to be removed in 0.3. Use Format instead
+ * a video format
  */
-class Stream
+class Format
 {
 	/**
 	 * Creates a Stream from array
@@ -27,14 +19,21 @@ class Stream
 	 *
 	 * @param VideoInfo $video_info
 	 * @param array $stream_info
+	 * @param array $config
 	 * @return Stream
 	 */
-	public static function createFromArray(VideoInfo $video_info, array $stream_info)
+	public static function createFromArray(
+		VideoInfo $video_info,
+		array $stream_info,
+		array $config
+		)
 	{
-		return new self($video_info, $stream_info);
+		return new self($video_info, $stream_info, $config);
 	}
 
 	private $video_info;
+
+	private $config = [];
 
 	private $data = [];
 
@@ -47,9 +46,13 @@ class Stream
 	 * @param array $data
 	 * @return self
 	 */
-	private function __construct(VideoInfo $video_info, array $data)
+	private function __construct(VideoInfo $video_info, array $data, array $config)
 	{
 		$this->video_info = $video_info;
+
+		$this->config = [
+			'decipher_signature' => (isset($config['decipher_signature'])) ? (bool) $config['decipher_signature'] : false,
+		];
 
 		$allowed_keys = [
 			'itag',
@@ -98,11 +101,11 @@ class Stream
 		$signature = '';
 
 		// The video signature need to be deciphered
-		if (isset($this->raw_data['s']))
+		if ( isset($this->raw_data['s']) and $this->config['decipher_signature'] )
 		{
-			// Uncomment the following 2 lines to activate signature decipher
-			//$playerID = SignatureDecipher::downloadPlayerScript($this->getVideoId());
-			//$signature = '&ratebypass=yes&signature='.SignatureDecipher::decipherSignature($playerID, $this->raw_data['s']);
+			// TODO: Remove signature decipher from Format
+			$playerID = SignatureDecipher::downloadPlayerScript($this->getVideoId());
+			$signature = '&ratebypass=yes&signature='.SignatureDecipher::decipherSignature($playerID, $this->raw_data['s']);
 		}
 
 		$this->data['url'] = $this->raw_data['url'].$signature;

--- a/src/Format.php
+++ b/src/Format.php
@@ -40,7 +40,7 @@ class Format
 	private $raw_data = [];
 
 	/**
-	 * Creates a StreamMap from streams and formats arrays
+	 * Creates a Format from a format data array
 	 *
 	 * @param VideoInfo $video_info
 	 * @param array $data

--- a/src/StreamMap.php
+++ b/src/StreamMap.php
@@ -2,8 +2,16 @@
 
 namespace YoutubeDownloader;
 
+@trigger_error(
+	'StreamMap is deprecated since version 0.2, to be removed in 0.3. Use '.
+	'VideoInfo::getFormats() and VideoInfo::getAdaptiveFormats() instead',
+	E_USER_DEPRECATED
+);
+
 /**
  * StreamMap
+ *
+ * @deprecated since version 0.2, to be removed in 0.3. Use VideoInfo::getFormats() and VideoInfo::getAdaptiveFormats() instead
  */
 class StreamMap
 {

--- a/src/Template/Engine.php
+++ b/src/Template/Engine.php
@@ -11,7 +11,7 @@ class Engine
 	 * Creates the engine with a template directory
 	 *
 	 * @param VideoInfo $video_info
-	 * @return StreamMap
+	 * @return Engine
 	 */
 	public static function createFromDirectory($directory)
 	{

--- a/src/Toolkit.php
+++ b/src/Toolkit.php
@@ -260,9 +260,11 @@ class Toolkit
 
 		$best_format = $avail_formats[$best_format];
 
-		if ( ! empty($best_format->getUrl()) )
+		$redirect_url = $best_format->getUrl();
+
+		if ( ! empty($redirect_url) )
 		{
-			$redirect_url = $best_format->getUrl() . '&title=' . $cleanedtitle;
+			$redirect_url .= '&title=' . $cleanedtitle;
 		}
 
 		return $redirect_url;

--- a/src/Toolkit.php
+++ b/src/Toolkit.php
@@ -308,7 +308,7 @@ class Toolkit
 			}
 
 			// some video does not have adaptive or dash format, downloading video instead
-			$formats = $video_info->getAdaptiveFormats()();
+			$formats = $video_info->getAdaptiveFormats();
 
 			if (count($formats) === 0)
 			{

--- a/src/Toolkit.php
+++ b/src/Toolkit.php
@@ -2,6 +2,8 @@
 
 namespace YoutubeDownloader;
 
+use Exception;
+
 /**
  * Toolkit
  *
@@ -263,15 +265,20 @@ class Toolkit
 		return $redirect_url;
 	}
 
-	public function getDownloadMP3($video_id, Config $config)
+	/**
+	 * @param StreamMap $stream_map
+	 * @param Config $config
+	 *
+	 * @throws Exception
+	 *
+	 * @return bool
+	 */
+	public function getDownloadMP3(StreamMap $stream_map, Config $config)
 	{
-		// generate new url, we can re-use previously generated link and pass it to "token" parameter but it too dangerous to use it with exec()
+		// generate new url, we can re-use previously generated link and pass it
+		// to "token" parameter, but it is too dangerous to use it with exec()
 		// TODO: Background conversion, Ajax and Caching
 		// @ewwink
-		$video_info_url = 'https://www.youtube.com/get_video_info?&video_id=' . $video_id. '&asv=3&el=detailpage&hl=en_US';
-		$video_info_string = self::curlGet($video_info_url, $config);
-		$video_info = \YoutubeDownloader\VideoInfo::createFromString($video_info_string);
-		$stream_map = \YoutubeDownloader\StreamMap::createFromVideoInfo($video_info);
 		$audio_quality = 0;
 		$media_url = "";
 		$media_type = "";
@@ -290,20 +297,23 @@ class Toolkit
 
 		if(empty($media_url))
 		{
-			if($config->get('MP3ConvertVideo') === true )
+			if( $config->get('MP3ConvertVideo') !== true )
 			{
-				// some video does not have adaptive or dash format, downloading video instead
-				$formats = $stream_map->getStreams();
-				$media_url = $formats[0]['url'];
-				$media_type = str_replace("audio/", "", $formats[0]['type']);
-			}
-			else
-			{
-				return array(
-					"status" => "failed",
-					"message" => "Failed, adaptive audio format not available, try to set <strong>\$config->get('MP3ConvertVideo') = true;</strong>"
+				throw new Exception(
+					'MP3 downlod failed, adaptive audio format not available, try to set config "MP3ConvertVideo" to true'
 				);
 			}
+
+			// some video does not have adaptive or dash format, downloading video instead
+			$formats = $stream_map->getStreams();
+
+			if (count($formats) === 0)
+			{
+				throw new Exception('MP3 downlod failed, no stream was found.');
+			}
+
+			$media_url = $formats[0]['url'];
+			$media_type = str_replace("audio/", "", $formats[0]['type']);
 		}
 
 		$mp3dir = realpath($config->get('MP3TempDir'));
@@ -312,34 +322,35 @@ class Toolkit
 		$cmd = '"' . $config->get('aria2Path') . '"' . " -x4 -k1M --continue=true --dir=\"$mp3dir\" --out=$mediaName \"$media_url\" 2>&1" ;
 		exec($cmd, $output);
 
-		if(strpos(implode(" ", $output), "download completed") !== FALSE)
+		if(strpos(implode(" ", $output), "download completed") === false)
 		{
-			// Download media from youtube success
-			$mp3Name = $_GET['title'] . '.mp3';
-			if($config->get('MP3Quality') !== "high" || $audio_quality === 0)
-			{
-				$audio_quality = intval($config->get('MP3Quality')) > intval($audio_quality) ? $audio_quality : $config->get('MP3Quality');
-			}
+			$e = new Exception($output[0]);
 
-			$cmd = '"' . $config->get('ffmpegPath') . '"' . " -i \"$mp3dir/$mediaName\" -b:a $audio_quality -vn \"$mp3dir/$mp3Name\" 2>&1";
-
-			exec($cmd, $output);
-			if(strpos(implode(" ", $output), "Output #0, mp3") !== FALSE || file_exists("$mp3dir/$mp3Name"))
-			{
-				// Convert media to .mp3 success
-				return array(
-					"status" => "success",
-					"message" => "Convert media to .mp3 success",
-					"mp3" => "$mp3dir/$mp3Name",
-					"debugMessage" => $output
-				);
-			}
+			throw new Exception(
+				'Download media url from youtube failed.',
+				0,
+				$e
+			);
 		}
-		else
+
+		// Download media from youtube success
+		$mp3Name = $_GET['title'] . '.mp3';
+		if($config->get('MP3Quality') !== "high" || $audio_quality === 0)
 		{
+			$audio_quality = intval($config->get('MP3Quality')) > intval($audio_quality) ? $audio_quality : $config->get('MP3Quality');
+		}
+
+		$cmd = '"' . $config->get('ffmpegPath') . '"' . " -i \"$mp3dir/$mediaName\" -b:a $audio_quality -vn \"$mp3dir/$mp3Name\" 2>&1";
+
+		exec($cmd, $output);
+
+		if(strpos(implode(" ", $output), "Output #0, mp3") !== FALSE || file_exists("$mp3dir/$mp3Name"))
+		{
+			// Convert media to .mp3 success
 			return array(
-				"status" => "failed",
-				"message" => "Download media url from youtube failed.",
+				"status" => "success",
+				"message" => "Convert media to .mp3 success",
+				"mp3" => "$mp3dir/$mp3Name",
 				"debugMessage" => $output
 			);
 		}

--- a/src/VideoInfo.php
+++ b/src/VideoInfo.php
@@ -208,7 +208,6 @@ class VideoInfo
 			];
 		}
 
-
 		foreach ($this->allowed_keys as $key)
 		{
 			if ( isset($video_info[$key]) )
@@ -232,22 +231,27 @@ class VideoInfo
 	/**
 	 * Parses an array of formats
 	 *
-	 * @param array $formats
+	 * @param array $format_array
 	 * @param array $config
 	 * @return array
 	 */
-	private function parseFormats(array $formats, array $config)
+	private function parseFormats(array $format_array, array $config)
 	{
 		$formats = [];
 
-		if (count($formats) === 1 and $formats[0] === '' )
+		if (count($format_array) === 1 and $format_array[0] === '' )
 		{
 			return $formats;
 		}
 
-		foreach ($formats as $format)
+		foreach ($format_array as $format)
 		{
 			parse_str($format, $format_info);
+
+			if ( count($format_info) <= 1 )
+			{
+				continue;
+			}
 
 			$formats[] = Format::createFromArray($this, $format_info, $config);
 		}
@@ -324,7 +328,7 @@ class VideoInfo
 	 */
 	public function getFormats()
 	{
-		return $this->formats;;
+		return $this->formats;
 	}
 
 	/**

--- a/templates/error.php
+++ b/templates/error.php
@@ -1,6 +1,8 @@
 <?php echo $this->inc('header.php', ['title' => 'Youtube Downloader Error']); ?>
-	<div class="container-fluid">
-		<h1>Youtube Downloader Error</h1>
-		<p><?php echo $this->get('error_message'); ?></p>
-	</div>
+<div class="download">
+	<h1 class="download-heading">Youtube Downloader Error</h1>
+	<p><?php echo $this->get('error_message'); ?></p>
+	<hr />
+	<p class="muted"><a href="https://github.com/jeckman/YouTube-Downloader" target="_blank">Youtube Downloader <?php echo $this->get('app_version', ''); ?></a> is licensed under GPL 2.</p>
+</div>
 <?php echo $this->inc('footer.php'); ?>

--- a/templates/getvideo.php
+++ b/templates/getvideo.php
@@ -67,7 +67,7 @@ else
 	<p align="center">Convert and Download to .mp3</p>
 	<ul>
 		<li>
-			<strong><a href="<?php echo $format['mp3_download_url']; ?>" class="mime">audio/mp3</a> (quality: <?php echo $format['mp3_download_quality']; ?>)</strong>
+			<a href="<?php echo $this->get('mp3_download_url'); ?>" class="mime">audio/mp3</a> (quality: <?php echo $this->get('mp3_download_quality'); ?>)
 		</li>
 	</ul>
 <?php } ?>

--- a/tests/Unit/FormatTest.php
+++ b/tests/Unit/FormatTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace YoutubeDownloader\Tests\Unit;
+
+use YoutubeDownloader\Format;
+use YoutubeDownloader\Tests\Fixture\TestCase;
+
+class FormatTest extends TestCase
+{
+	public function setUp()
+	{
+		$this->tz_backup = date_default_timezone_get();
+		date_default_timezone_set('UTC');
+	}
+
+	public function tearDown()
+	{
+		date_default_timezone_set($this->tz_backup);
+	}
+
+	/**
+	 * @test createFromArray()
+	 */
+	public function createFromArray()
+	{
+		$format_data = [
+			'itag' => '22',
+			'quality' => 'hd720',
+			'type' => 'video/mp4',
+			'url' => 'https://r4---sn-xjpm-q0ns.googlevideo.com/videoplayback?mime=video%2Fmp4&dur=3567.629&id=o-ALLJQEDdJCHuwXcL9toC3Iim4AvgjxD3lzAyP_l8I3i6&pl=23&itag=22&ratebypass=yes&mt=1495797277&ms=au&requiressl=yes&mn=sn-xjpm-q0ns&mm=31&source=youtube&sparams=dur%2Cei%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cpl%2Cratebypass%2Crequiressl%2Csource%2Cexpire&key=yt6&lmt=1471747682170867&signature=B6A1CD71B2245C40BCC26B71BF9DC15545591BE1.DB1653D145BC156D1A3C13F24B63B08BD10F86AB&ei=gQ4oWf3TNsGVceLmsagP&expire=1495818977&ip=211.12.135.54&mv=m&initcwndbps=1286250&ipbits=0',
+			'expires' => '21:46:17 IRDT',
+			'ipbits' => '0',
+			'ip' => '211.12.135.54',
+		];
+
+		$video_info = $this->createMock('\\YoutubeDownloader\\VideoInfo');
+		$video_info->method('getVideoId')->willReturn('ScNNfyq3d_w');
+
+		$config = [];
+
+		$format = Format::createFromArray($video_info, $format_data, $config);
+
+		$this->assertInstanceOf('\\YoutubeDownloader\\Format', $format);
+
+		return $format;
+	}
+
+	/**
+	 * @test getVideoId()
+	 */
+	public function getVideoId()
+	{
+		// We cannot use @depends on createFromArray because of a bug in
+		// PHPUnit 4 that remove the mocked methods in the mocked VideoInfo.
+		// Instead we call $this->createFromArray() directly.
+		$format = $this->createFromArray();
+
+		$this->assertSame('ScNNfyq3d_w', $format->getVideoId());
+	}
+
+	/**
+	 * @test getUrl()
+	 * @depends createFromArray
+	 */
+	public function getUrl(Format $format)
+	{
+		$this->assertSame(
+			'https://r4---sn-xjpm-q0ns.googlevideo.com/videoplayback?mime=video%2Fmp4&dur=3567.629&id=o-ALLJQEDdJCHuwXcL9toC3Iim4AvgjxD3lzAyP_l8I3i6&pl=23&itag=22&ratebypass=yes&mt=1495797277&ms=au&requiressl=yes&mn=sn-xjpm-q0ns&mm=31&source=youtube&sparams=dur%2Cei%2Cid%2Cinitcwndbps%2Cip%2Cipbits%2Citag%2Clmt%2Cmime%2Cmm%2Cmn%2Cms%2Cmv%2Cpl%2Cratebypass%2Crequiressl%2Csource%2Cexpire&key=yt6&lmt=1471747682170867&signature=B6A1CD71B2245C40BCC26B71BF9DC15545591BE1.DB1653D145BC156D1A3C13F24B63B08BD10F86AB&ei=gQ4oWf3TNsGVceLmsagP&expire=1495818977&ip=211.12.135.54&mv=m&initcwndbps=1286250&ipbits=0',
+			$format->getUrl()
+		);
+	}
+
+	/**
+	 * @test getItag()
+	 * @depends createFromArray
+	 */
+	public function getItag(Format $format)
+	{
+		$this->assertSame('22', $format->getItag());
+	}
+
+	/**
+	 * @test getQuality()
+	 * @depends createFromArray
+	 */
+	public function getQuality(Format $format)
+	{
+		$this->assertSame('hd720', $format->getQuality());
+	}
+
+	/**
+	 * @test getType()
+	 * @depends createFromArray
+	 */
+	public function getType(Format $format)
+	{
+		$this->assertSame('video/mp4', $format->getType());
+	}
+
+	/**
+	 * @test getExpires()
+	 * @depends createFromArray
+	 */
+	public function getExpires(Format $format)
+	{
+		$this->assertSame('17:16:17 UTC', $format->getExpires());
+	}
+
+	/**
+	 * @test getIpbits()
+	 * @depends createFromArray
+	 */
+	public function getIpbits(Format $format)
+	{
+		$this->assertSame('0', $format->getIpbits());
+	}
+
+	/**
+	 * @test getIp()
+	 * @depends createFromArray
+	 */
+	public function getIp(Format $format)
+	{
+		$this->assertSame('211.12.135.54', $format->getIp());
+	}
+}

--- a/tests/Unit/VideoInfoTest.php
+++ b/tests/Unit/VideoInfoTest.php
@@ -11,7 +11,23 @@ class VideoInfoTest extends \YoutubeDownloader\Tests\Fixture\TestCase
 	 */
 	public function createFromString()
 	{
-		$this->assertInstanceOf('YoutubeDownloader\VideoInfo', VideoInfo::createFromString(''));
+		$this->assertInstanceOf(
+			'\\YoutubeDownloader\\VideoInfo',
+			VideoInfo::createFromString('')
+		);
+	}
+
+	/**
+	 * @test createFromStringWithConfig()
+	 */
+	public function createFromStringWithConfig()
+	{
+		$config = $this->createMock('\\YoutubeDownloader\\Config');
+
+		$this->assertInstanceOf(
+			'\\YoutubeDownloader\\VideoInfo',
+			VideoInfo::createFromStringWithConfig('', $config)
+		);
 	}
 
 	/**
@@ -87,13 +103,33 @@ class VideoInfoTest extends \YoutubeDownloader\Tests\Fixture\TestCase
 	}
 
 	/**
+	 * @test getFormats()
+	 */
+	public function getFormatsIsEmptyArray()
+	{
+		$video_info = VideoInfo::createFromString('url_encoded_fmt_stream_map=formats');
+
+		$this->assertSame([], $video_info->getFormats());
+	}
+
+	/**
+	 * @test getAdaptiveFormats()
+	 */
+	public function getAdaptiveFormatsIsEmptyArray()
+	{
+		$video_info = VideoInfo::createFromString('adaptive_fmts=adaptive_formats');
+
+		$this->assertSame([], $video_info->getAdaptiveFormats());
+	}
+
+	/**
 	 * @test getStreamMapString()
 	 */
 	public function getStreamMapString()
 	{
-		$video_info = VideoInfo::createFromString('url_encoded_fmt_stream_map=stream_map');
+		$video_info = VideoInfo::createFromString('url_encoded_fmt_stream_map=formats');
 
-		$this->assertSame('stream_map', $video_info->getStreamMapString());
+		$this->assertSame('formats', $video_info->getStreamMapString());
 	}
 
 	/**
@@ -101,8 +137,8 @@ class VideoInfoTest extends \YoutubeDownloader\Tests\Fixture\TestCase
 	 */
 	public function getAdaptiveFormatsString()
 	{
-		$video_info = VideoInfo::createFromString('adaptive_fmts=formats');
+		$video_info = VideoInfo::createFromString('adaptive_fmts=adaptive_formats');
 
-		$this->assertSame('formats', $video_info->getAdaptiveFormatsString());
+		$this->assertSame('adaptive_formats', $video_info->getAdaptiveFormatsString());
 	}
 }


### PR DESCRIPTION
I've done some refactoring and created a new class `Format`. The class `VideoInfo` delivers now the different formats for a video. The classes `StreamMap` and `Stream` are now deprecated and will be removed in the next release.

Btw: I've added a new config `enable_youtube_decipher_signature` to enable the signature decipher per config. 🙂 
