### PR TITLE
New PSR-3 compatible Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ composer.phar
 composer.lock
 config/custom.php
 Deciphers.log
+logs/*
 vendor

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ cache/*
 composer.phar
 composer.lock
 config/custom.php
-Deciphers.log
 logs/*
 vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- new PSR-3 compatible logger implementation `Logger\Logger` to log all kind of events
+- `SimpleContainer` has a new `logger` service with a `Logger\Logger` instance 
+- new folder `/logs` for log files
+- `Format` implements `Logger\LoggerAware` interface
+- `VideoInfo` implements `Logger\LoggerAware` interface
+- `SignatureDecipher::decipherSignatureWithRawPlayerScript()` expects an optional logger as 3rd parameter
+
+### Changed
+
+- Logs are now stored in `/logs`, the file `Deciphers.log` can be deleted
+
 ### Removed
 
 - **Breaking** method `SignatureDecipher::downloadPlayerScript()` was removed, use `SignatureDecipher::downloadRawPlayerScript()` instead
@@ -16,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- new PSR-16 compatible cache implemantation `Cache\FileCache` to store data in the filesystem
+- new PSR-16 compatible cache implementation `Cache\FileCache` to store data in the filesystem
 - `SignatureDecipher::getPlayerInfoByVideoId()` to get the player ID and player url of a cipher video
 - `SignatureDecipher::downloadRawPlayerScript()` to download the raw player script of a cipher video
 - `SignatureDecipher::decipherSignatureWithRawPlayerScript()` to decipher a signature with a raw dicipher script

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -82,36 +82,47 @@ $container = call_user_func_array(
 		$container->set('cache', $cache);
 
 		// Create Logger
-		$now = new \DateTime('now', new \DateTimeZone($config->get('default_timezone')));
-
-		$filepath = sprintf(
-			'%s' . \DIRECTORY_SEPARATOR . '%s',
-			__DIR__ . \DIRECTORY_SEPARATOR . 'logs',
-			$now->format('Y')
+		$logger = new \YoutubeDownloader\Logger\HandlerAwareLogger(
+			new \YoutubeDownloader\Logger\Handler\NullHandler()
 		);
 
-		if ( ! file_exists($filepath) )
+		if ( $config->get('debug') === true )
 		{
-			mkdir($filepath);
+			# code...
+			$now = new \DateTime('now', new \DateTimeZone($config->get('default_timezone')));
+
+			$filepath = sprintf(
+				'%s' . \DIRECTORY_SEPARATOR . '%s',
+				__DIR__ . \DIRECTORY_SEPARATOR . 'logs',
+				$now->format('Y')
+			);
+
+			if ( ! file_exists($filepath) )
+			{
+				mkdir($filepath);
+			}
+
+			$stream = fopen(
+				$filepath . \DIRECTORY_SEPARATOR . $now->format('Y-m-d') . '.log',
+				'a+'
+			);
+
+			if ( is_resource($stream) )
+			{
+				$handler = new \YoutubeDownloader\Logger\Handler\StreamHandler($stream, [
+					\YoutubeDownloader\Logger\LogLevel::EMERGENCY,
+					\YoutubeDownloader\Logger\LogLevel::ALERT,
+					\YoutubeDownloader\Logger\LogLevel::CRITICAL,
+					\YoutubeDownloader\Logger\LogLevel::ERROR,
+					\YoutubeDownloader\Logger\LogLevel::WARNING,
+					\YoutubeDownloader\Logger\LogLevel::NOTICE,
+					\YoutubeDownloader\Logger\LogLevel::INFO,
+					\YoutubeDownloader\Logger\LogLevel::DEBUG,
+				]);
+
+				$logger->addHandler($handler);
+			}
 		}
-
-		$stream = fopen(
-			$filepath . \DIRECTORY_SEPARATOR . $now->format('Y-m-d') . '.log',
-			'a+'
-		);
-
-		$handler = new \YoutubeDownloader\Logger\Handler\StreamHandler($stream, [
-			\YoutubeDownloader\Logger\LogLevel::EMERGENCY,
-			\YoutubeDownloader\Logger\LogLevel::ALERT,
-			\YoutubeDownloader\Logger\LogLevel::CRITICAL,
-			\YoutubeDownloader\Logger\LogLevel::ERROR,
-			\YoutubeDownloader\Logger\LogLevel::WARNING,
-			\YoutubeDownloader\Logger\LogLevel::NOTICE,
-			\YoutubeDownloader\Logger\LogLevel::INFO,
-			\YoutubeDownloader\Logger\LogLevel::DEBUG,
-		]);
-
-		$logger = new \YoutubeDownloader\Logger\HandlerAwareLogger($handler);
 
 		$container->set('logger', $logger);
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -81,6 +81,40 @@ $container = call_user_func_array(
 
 		$container->set('cache', $cache);
 
+		// Create Logger
+		$now = new \DateTime('now', new \DateTimeZone($config->get('default_timezone')));
+
+		$filepath = sprintf(
+			'%s' . \DIRECTORY_SEPARATOR . '%s',
+			__DIR__ . \DIRECTORY_SEPARATOR . 'logs',
+			$now->format('Y')
+		);
+
+		if ( ! file_exists($filepath) )
+		{
+			mkdir($filepath);
+		}
+
+		$stream = fopen(
+			$filepath . \DIRECTORY_SEPARATOR . $now->format('Y-m-d') . '.log',
+			'a+'
+		);
+
+		$handler = new \YoutubeDownloader\Logger\Handler\StreamHandler($stream, [
+			\YoutubeDownloader\Logger\LogLevel::EMERGENCY,
+			\YoutubeDownloader\Logger\LogLevel::ALERT,
+			\YoutubeDownloader\Logger\LogLevel::CRITICAL,
+			\YoutubeDownloader\Logger\LogLevel::ERROR,
+			\YoutubeDownloader\Logger\LogLevel::WARNING,
+			\YoutubeDownloader\Logger\LogLevel::NOTICE,
+			\YoutubeDownloader\Logger\LogLevel::INFO,
+			\YoutubeDownloader\Logger\LogLevel::DEBUG,
+		]);
+
+		$logger = new \YoutubeDownloader\Logger\HandlerAwareLogger($handler);
+
+		$container->set('logger', $logger);
+
 		return $container;
 	},
 	[getenv('CONFIG_ENV') ?: 'custom']

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "mikey179/vfsStream": "^1.6",
         "phpunit/phpunit": "^4.8.35 || ^6.0",
         "psr/container": "^1.0",
+        "psr/log": "^1.0",
         "psr/simple-cache": "^1.0"
     },
     "autoload": {

--- a/src/Application/App.php
+++ b/src/Application/App.php
@@ -29,6 +29,8 @@ class App
 	public function __construct(Container $container)
 	{
 		$this->container = $container;
+
+		$this->getContainer()->get('logger')->debug('App started');
 	}
 
 	/**

--- a/src/Application/App.php
+++ b/src/Application/App.php
@@ -67,5 +67,7 @@ class App
 		$controller = $controller_factory->make($route, $this);
 
 		$controller->execute();
+
+		$this->getContainer()->get('logger')->debug('Controller executed. App closed.');
 	}
 }

--- a/src/Application/ControllerAbstract.php
+++ b/src/Application/ControllerAbstract.php
@@ -19,6 +19,11 @@ abstract class ControllerAbstract implements Controller
 	public function __construct(App $app)
 	{
 		$this->app = $app;
+
+		$this->get('logger')->debug(
+			'{controller_name} created',
+			['controller_name' => get_class($this)]
+		);
 	}
 
 	/**

--- a/src/Application/DownloadController.php
+++ b/src/Application/DownloadController.php
@@ -69,6 +69,11 @@ class DownloadController extends ControllerAbstract
 				$video_info = \YoutubeDownloader\VideoInfo::createFromStringWithConfig($video_info_string, $config);
 				$video_info->setCache($this->get('cache'));
 
+				if ( $video_info instanceOf \YoutubeDownloader\Logger\LoggerAware )
+				{
+					$video_info->setLogger($this->get('logger'));
+				}
+
 				try
 				{
 					$mp3_info = $toolkit->getDownloadMP3($video_info, $config);

--- a/src/Application/ResultController.php
+++ b/src/Application/ResultController.php
@@ -63,6 +63,11 @@ class ResultController extends ControllerAbstract
 		$video_info = \YoutubeDownloader\VideoInfo::createFromStringWithConfig($video_info_string, $config);
 		$video_info->setCache($this->get('cache'));
 
+		if ( $video_info instanceOf \YoutubeDownloader\Logger\LoggerAware )
+		{
+			$video_info->setLogger($this->get('logger'));
+		}
+
 		if ($video_info->getStatus() == 'fail')
 		{
 			$message = 'Error in video ID: ' . $video_info->getErrorReason();

--- a/src/Format.php
+++ b/src/Format.php
@@ -2,11 +2,16 @@
 
 namespace YoutubeDownloader;
 
+use YoutubeDownloader\Logger\LoggerAware;
+use YoutubeDownloader\Logger\LoggerAwareTrait;
+
 /**
  * a video format
  */
-class Format
+class Format implements LoggerAware
 {
+	use LoggerAwareTrait;
+
 	/**
 	 * Creates a Stream from array
 	 *
@@ -36,6 +41,8 @@ class Format
 	private $config = [];
 
 	private $data = [];
+
+	private $data_parsed = false;
 
 	private $raw_data = [];
 
@@ -74,8 +81,6 @@ class Format
 		}
 
 		$this->raw_data = $data;
-
-		$this->parseUrl();
 	}
 
 	/**
@@ -85,6 +90,11 @@ class Format
 	 */
 	private function parseUrl()
 	{
+		if ( $this->data_parsed === true )
+		{
+			return;
+		}
+
 		parse_str(urldecode($this->data['url']), $url_info);
 
 		if (isset($this->raw_data['bitrate']))
@@ -122,7 +132,8 @@ class Format
 
 			$sig = SignatureDecipher::decipherSignatureWithRawPlayerScript(
 				$decipherScript,
-				$this->raw_data['s']
+				$this->raw_data['s'],
+				$this->getLogger()
 			);
 
 			if ( strpos($this->raw_data['url'], 'ratebypass=') === false )
@@ -141,6 +152,8 @@ class Format
 		$this->data['expires'] = isset($url_info['expire']) ? date("G:i:s T", $url_info['expire']) : '';
 		$this->data['ipbits'] = isset($url_info['ipbits']) ? $url_info['ipbits'] : '';
 		$this->data['ip'] = isset($url_info['ip']) ? $url_info['ip'] : '';
+
+		$this->data_parsed = true;
 	}
 
 	/**
@@ -160,6 +173,8 @@ class Format
 	 */
 	public function getUrl()
 	{
+		$this->parseUrl();
+
 		return $this->data['url'];
 	}
 
@@ -170,6 +185,8 @@ class Format
 	 */
 	public function getItag()
 	{
+		$this->parseUrl();
+
 		return $this->data['itag'];
 	}
 
@@ -180,6 +197,8 @@ class Format
 	 */
 	public function getQuality()
 	{
+		$this->parseUrl();
+
 		return $this->data['quality'];
 	}
 
@@ -190,6 +209,8 @@ class Format
 	 */
 	public function getType()
 	{
+		$this->parseUrl();
+
 		return $this->data['type'];
 	}
 
@@ -200,6 +221,8 @@ class Format
 	 */
 	public function getExpires()
 	{
+		$this->parseUrl();
+
 		return $this->data['expires'];
 	}
 
@@ -210,6 +233,8 @@ class Format
 	 */
 	public function getIpbits()
 	{
+		$this->parseUrl();
+
 		return $this->data['ipbits'];
 	}
 
@@ -220,6 +245,8 @@ class Format
 	 */
 	public function getIp()
 	{
+		$this->parseUrl();
+
 		return $this->data['ip'];
 	}
 }

--- a/src/Logger/Handler/Entry.php
+++ b/src/Logger/Handler/Entry.php
@@ -31,7 +31,7 @@ interface Entry
 	/**
 	 * Returns the created DateTime
 	 *
-	 * @return DateTimeImmutable
+	 * @return DateTime
 	 */
 	public function getCreatedAt();
 }

--- a/src/Logger/Handler/Entry.php
+++ b/src/Logger/Handler/Entry.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace YoutubeDownloader\Logger\Handler;
+
+/**
+ * An entry interface for a handler instance
+ */
+interface Entry
+{
+	/**
+	 * Returns the message
+	 *
+	 * @return string
+	 */
+	public function getMessage();
+
+	/**
+	 * Returns the context
+	 *
+	 * @return array
+	 */
+	public function getContext();
+
+	/**
+	 * Returns the level
+	 *
+	 * @return string
+	 */
+	public function getLevel();
+
+	/**
+	 * Returns the created DateTime
+	 *
+	 * @return DateTimeImmutable
+	 */
+	public function getCreatedAt();
+}

--- a/src/Logger/Handler/Handler.php
+++ b/src/Logger/Handler/Handler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace YoutubeDownloader\Logger\Handler;
+
+/**
+ * Describes a handler instance
+ */
+interface Handler
+{
+	/**
+	 * Check if this handler handels a log level
+	 *
+	 * @param string $level A valid log level from LogLevel class
+	 * @return boolean
+	 */
+	public function handles($level);
+
+	/**
+	 * Handle an entry
+	 *
+	 * @param Entry $entry
+	 * @return boolean
+	 */
+	public function handle(Entry $entry);
+}

--- a/src/Logger/Handler/NullHandler.php
+++ b/src/Logger/Handler/NullHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace YoutubeDownloader\Logger\Handler;
+
+/**
+ * a handler instance that handles no entries
+ */
+class NullHandler implements Handler
+{
+	/**
+	 * Check if this handler handels a log level
+	 *
+	 * @param string $level A valid log level from LogLevel class
+	 * @return boolean
+	 */
+	public function handles($level)
+	{
+		return false;
+	}
+
+	/**
+	 * Handle an entry
+	 *
+	 * @param Entry $entry
+	 * @return boolean
+	 */
+	public function handle(Entry $entry)
+	{
+		return false;
+	}
+}

--- a/src/Logger/Handler/SimpleEntry.php
+++ b/src/Logger/Handler/SimpleEntry.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace YoutubeDownloader\Logger\Handler;
+
+use DateTimeImmutable;
+
+/**
+ * An simple entry instance
+ */
+class SimpleEntry implements Entry
+{
+	private $message;
+	private $context;
+	private $level;
+	private $created_at;
+
+	/**
+	 * Create an entry
+	 *
+	 * @param DateTimeImmutable $created_at
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 * @return self
+	 */
+	public function __construct(DateTimeImmutable $created_at, $level, $message, array $context = array())
+	{
+		$this->created_at = $created_at;
+		$this->level = $level;
+		$this->message = $message;
+		$this->context = $context;
+	}
+
+	/**
+	 * Returns the message
+	 *
+	 * @return string
+	 */
+	public function getMessage()
+	{
+		return $this->message;
+	}
+
+	/**
+	 * Returns the context
+	 *
+	 * @return array
+	 */
+	public function getContext()
+	{
+		return $this->context;
+	}
+
+	/**
+	 * Returns the level
+	 *
+	 * @return string
+	 */
+	public function getLevel()
+	{
+		return $this->level;
+	}
+
+	/**
+	 * Returns the created DateTime
+	 *
+	 * @return DateTimeImmutable
+	 */
+	public function getCreatedAt()
+	{
+		return $this->created_at;
+	}
+}

--- a/src/Logger/Handler/SimpleEntry.php
+++ b/src/Logger/Handler/SimpleEntry.php
@@ -2,7 +2,7 @@
 
 namespace YoutubeDownloader\Logger\Handler;
 
-use DateTimeImmutable;
+use DateTime;
 
 /**
  * An simple entry instance
@@ -17,13 +17,13 @@ class SimpleEntry implements Entry
 	/**
 	 * Create an entry
 	 *
-	 * @param DateTimeImmutable $created_at
+	 * @param DateTime $created_at
 	 * @param mixed $level
 	 * @param string $message
 	 * @param array $context
 	 * @return self
 	 */
-	public function __construct(DateTimeImmutable $created_at, $level, $message, array $context = array())
+	public function __construct(DateTime $created_at, $level, $message, array $context = array())
 	{
 		$this->created_at = $created_at;
 		$this->level = $level;
@@ -64,7 +64,7 @@ class SimpleEntry implements Entry
 	/**
 	 * Returns the created DateTime
 	 *
-	 * @return DateTimeImmutable
+	 * @return DateTime
 	 */
 	public function getCreatedAt()
 	{

--- a/src/Logger/Handler/StreamHandler.php
+++ b/src/Logger/Handler/StreamHandler.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace YoutubeDownloader\Logger\Handler;
+
+/**
+ * A handler that saves an entries per line in a stream
+ */
+class StreamHandler implements Handler
+{
+	private $template = "[%datetime%] %level_name%: %message%\n";
+
+	/**
+	 * Check if this handler handels a log level
+	 *
+	 * @param resource $stream A writable stream
+	 * @param array $levels An array with levels handles by this handler
+	 * @return self
+	 */
+	public function __construct($stream, array $levels)
+	{
+		if ( ! is_resource($stream) )
+		{
+			throw new \Exception('Parameter 1 must be a resource');
+		}
+
+		$meta = stream_get_meta_data($stream);
+
+		$writable_modes = [
+			'w' => true,
+			'w+' => true,
+			'rw' => true,
+			'r+' => true,
+			'x+' => true,
+			'c+' => true,
+			'wb' => true,
+			'w+b' => true,
+			'r+b' => true,
+			'x+b' => true,
+			'c+b' => true,
+			'w+t' => true,
+			'r+t' => true,
+			'x+t' => true,
+			'c+t' => true,
+			'a' => true,
+			'a+' => true,
+		];
+
+		if ( ! array_key_exists($meta['mode'], $writable_modes) )
+		{
+			throw new \Exception('The resource must be writable.');
+		}
+
+		$this->stream = $stream;
+
+		foreach ($levels as $level)
+		{
+			$this->levels[] = strval($level);
+		}
+	}
+
+	/**
+	 * Check if this handler handels a log level
+	 *
+	 * @param string $level A valid log level from LogLevel class
+	 * @return boolean
+	 */
+	public function handles($level)
+	{
+		return array_key_exists(strval($level), array_flip($this->levels));
+	}
+
+	/**
+	 * Handle an entry
+	 *
+	 * @param Entry $entry
+	 * @return boolean
+	 */
+	public function handle(Entry $entry)
+	{
+		if ( ! $this->handles($entry->getLevel()) )
+		{
+			return false;
+		}
+
+		fwrite($this->stream, $this->formatEntry($entry));
+
+		return true;
+	}
+
+	/**
+	 * Format an entry to a single line
+	 *
+	 * @param Entry $entry
+	 * @return string
+	 */
+	private function formatEntry(Entry $entry)
+	{
+		$message = $this->interpolate($entry->getMessage(), $entry->getContext());
+
+		$replace = [
+			'%datetime%' => $entry->getCreatedAt()->format('Y-m-d\TH:i:sP'),
+			'%level_name%' => $entry->getLevel(),
+			'%message%' => $this->removeLinebreaks($message),
+		];
+
+		return strtr($this->template, $replace);
+	}
+
+	/**
+	 * Interpolates context values into the message placeholders.
+	 *
+	 * @see http://www.php-fig.org/psr/psr-3/
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return string
+	 */
+	private function interpolate($message, array $context = [])
+	{
+		// build a replacement array with braces around the context keys
+		$replace = [];
+
+		foreach ($context as $key => $val)
+		{
+			// check that the value can be casted to string
+			if ( ! is_array($val) && ( ! is_object($val) || method_exists($val, '__toString') ) )
+			{
+				$replace['{' . $key . '}'] = strval($val);
+			}
+		}
+
+		// interpolate replacement values into the message and return
+		return strtr($message, $replace);
+	}
+
+	/**
+	 * Remove all linebreaks in a string
+	 *
+	 * @param string $message
+	 * @return string
+	 */
+	private function removeLinebreaks($message)
+	{
+		return str_replace(["\r\n", "\r", "\n"], ' ', $message);
+	}
+}

--- a/src/Logger/HandlerAwareLogger.php
+++ b/src/Logger/HandlerAwareLogger.php
@@ -161,7 +161,7 @@ class HandlerAwareLogger implements Logger
 	 * @param YoutubeDownloader\Logger\Handler\Handler $handler
 	 * @return void
 	 */
-	private function addHandler(Handler $handler)
+	public function addHandler(Handler $handler)
 	{
 		$this->handlers[] = $handler;
 	}

--- a/src/Logger/HandlerAwareLogger.php
+++ b/src/Logger/HandlerAwareLogger.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace YoutubeDownloader\Logger;
+
+use DateTimeImmutable;
+use YoutubeDownloader\Logger\Handler\Entry;
+use YoutubeDownloader\Logger\Handler\Handler;
+use YoutubeDownloader\Logger\Handler\SimpleEntry;
+
+/**
+ * a logger instance, that works with handler
+ */
+class HandlerAwareLogger implements Logger
+{
+	/**
+	 * @var YoutubeDownloader\Logger\Handler\Handler[]
+	 */
+	private $handlers = [];
+
+	/**
+	 * This logger needs at least a handler
+	 *
+	 * @param YoutubeDownloader\Logger\Handler\Handler $handler
+	 * @return self
+	 */
+	public function __construct(Handler $handler)
+	{
+		$this->addHandler($handler);
+	}
+
+	/**
+	 * System is unusable.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function emergency($message, array $context = array())
+	{
+		$this->log(LogLevel::EMERGENCY, $message, $context);
+	}
+
+	/**
+	 * Action must be taken immediately.
+	 *
+	 * Example: Entire website down, database unavailable, etc. This should
+	 * trigger the SMS alerts and wake you up.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function alert($message, array $context = array())
+	{
+		return $this->log(LogLevel::ALERT, $message, $context);
+	}
+
+	/**
+	 * Critical conditions.
+	 *
+	 * Example: Application component unavailable, unexpected exception.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function critical($message, array $context = array())
+	{
+		return $this->log(LogLevel::CRITICAL, $message, $context);
+	}
+
+	/**
+	 * Runtime errors that do not require immediate action but should typically
+	 * be logged and monitored.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function error($message, array $context = array())
+	{
+		return $this->log(LogLevel::ERROR, $message, $context);
+	}
+
+	/**
+	 * Exceptional occurrences that are not errors.
+	 *
+	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
+	 * that are not necessarily wrong.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function warning($message, array $context = array())
+	{
+		return $this->log(LogLevel::WARNING, $message, $context);
+	}
+
+	/**
+	 * Normal but significant events.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function notice($message, array $context = array())
+	{
+		return $this->log(LogLevel::NOTICE, $message, $context);
+	}
+
+	/**
+	 * Interesting events.
+	 *
+	 * Example: User logs in, SQL logs.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function info($message, array $context = array())
+	{
+		return $this->log(LogLevel::INFO, $message, $context);
+	}
+
+	/**
+	 * Detailed debug information.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function debug($message, array $context = array())
+	{
+		return $this->log(LogLevel::DEBUG, $message, $context);
+	}
+
+	/**
+	 * Logs with an arbitrary level.
+	 *
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function log($level, $message, array $context = array())
+	{
+		$entry = $this->createEntry(
+			new DateTimeImmutable('now'),
+			$level,
+			$message,
+			$context
+		);
+
+		$this->handleEntry($entry);
+	}
+
+	/**
+	 * Adds a handler
+	 *
+	 * @param YoutubeDownloader\Logger\Handler\Handler $handler
+	 * @return void
+	 */
+	private function addHandler(Handler $handler)
+	{
+		$this->handlers[] = $handler;
+	}
+
+	/**
+	 * Factory for a new entry
+	 *
+	 * @param DateTimeImmutable $created_at
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 * @return YoutubeDownloader\Logger\Handler\Entry
+	 */
+	private function createEntry(DateTimeImmutable $created_at, $level, $message, array $context = array())
+	{
+		return new SimpleEntry($created_at, $level, $message, $context);
+	}
+
+	/**
+	 * Search for all handler that handles this entry and call them
+	 *
+	 * @param YoutubeDownloader\Logger\Handler\Entry $entry
+	 * @return void
+	 */
+	private function handleEntry(Entry $entry)
+	{
+		foreach ($this->handlers as $handler)
+		{
+			if ($handler->handles($entry->getLevel()))
+			{
+				$handler->handle($entry);
+			}
+		}
+	}
+}

--- a/src/Logger/HandlerAwareLogger.php
+++ b/src/Logger/HandlerAwareLogger.php
@@ -2,7 +2,7 @@
 
 namespace YoutubeDownloader\Logger;
 
-use DateTimeImmutable;
+use DateTime;
 use YoutubeDownloader\Logger\Handler\Entry;
 use YoutubeDownloader\Logger\Handler\Handler;
 use YoutubeDownloader\Logger\Handler\SimpleEntry;
@@ -146,7 +146,7 @@ class HandlerAwareLogger implements Logger
 	public function log($level, $message, array $context = array())
 	{
 		$entry = $this->createEntry(
-			new DateTimeImmutable('now'),
+			new DateTime('now'),
 			$level,
 			$message,
 			$context
@@ -169,13 +169,13 @@ class HandlerAwareLogger implements Logger
 	/**
 	 * Factory for a new entry
 	 *
-	 * @param DateTimeImmutable $created_at
+	 * @param DateTime $created_at
 	 * @param mixed $level
 	 * @param string $message
 	 * @param array $context
 	 * @return YoutubeDownloader\Logger\Handler\Entry
 	 */
-	private function createEntry(DateTimeImmutable $created_at, $level, $message, array $context = array())
+	private function createEntry(DateTime $created_at, $level, $message, array $context = array())
 	{
 		return new SimpleEntry($created_at, $level, $message, $context);
 	}

--- a/src/Logger/LogLevel.php
+++ b/src/Logger/LogLevel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace YoutubeDownloader\Logger;
+
+/**
+ * Describes log levels
+ *
+ * This class is compatible with PSR-3 Psr\Log\LogLevel
+ */
+class LogLevel
+{
+	const EMERGENCY = 'emergency';
+	const ALERT     = 'alert';
+	const CRITICAL  = 'critical';
+	const ERROR     = 'error';
+	const WARNING   = 'warning';
+	const NOTICE    = 'notice';
+	const INFO      = 'info';
+	const DEBUG     = 'debug';
+}

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace YoutubeDownloader\Logger;
+
+/**
+ * Describes a logger instance
+ *
+ * This interface is compatible with PSR-3 Psr\Log\LoggerInterface
+ *
+ * The message MUST be a string or object implementing __toString().
+ *
+ * The message MAY contain placeholders in the form: {foo} where foo
+ * will be replaced by the context data in key "foo".
+ *
+ * The context array can contain arbitrary data, the only assumption that
+ * can be made by implementors is that if an Exception instance is given
+ * to produce a stack trace, it MUST be in a key named "exception".
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md
+ * for the full interface specification.
+ */
+interface Logger
+{
+	/**
+	 * System is unusable.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function emergency($message, array $context = array());
+
+	/**
+	 * Action must be taken immediately.
+	 *
+	 * Example: Entire website down, database unavailable, etc. This should
+	 * trigger the SMS alerts and wake you up.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function alert($message, array $context = array());
+
+	/**
+	 * Critical conditions.
+	 *
+	 * Example: Application component unavailable, unexpected exception.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function critical($message, array $context = array());
+
+	/**
+	 * Runtime errors that do not require immediate action but should typically
+	 * be logged and monitored.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function error($message, array $context = array());
+
+	/**
+	 * Exceptional occurrences that are not errors.
+	 *
+	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
+	 * that are not necessarily wrong.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function warning($message, array $context = array());
+
+	/**
+	 * Normal but significant events.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function notice($message, array $context = array());
+
+	/**
+	 * Interesting events.
+	 *
+	 * Example: User logs in, SQL logs.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function info($message, array $context = array());
+
+	/**
+	 * Detailed debug information.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function debug($message, array $context = array());
+
+	/**
+	 * Logs with an arbitrary level.
+	 *
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function log($level, $message, array $context = array());
+}

--- a/src/Logger/LoggerAware.php
+++ b/src/Logger/LoggerAware.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace YoutubeDownloader\Logger;
+
+/**
+ * Describes a logger-aware instance
+ *
+ * This interface is compatible with PSR-3 Psr\Log\LoggerAwareInterface
+ */
+interface LoggerAware
+{
+	/**
+	 * Sets a logger instance on the object
+	 *
+	 * @param LoggerInterface $logger
+	 * @return null
+	 */
+	public function setLogger(Logger $logger);
+}

--- a/src/Logger/LoggerAwareTrait.php
+++ b/src/Logger/LoggerAwareTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace YoutubeDownloader\Logger;
+
+/**
+ * Trait for logger-aware instances
+ */
+trait LoggerAwareTrait
+{
+	/**
+	 * @var YoutubeDownloader\Logger\Logger
+	 */
+	protected $logger;
+
+	/**
+	 * Sets a logger instance on the object
+	 *
+	 * @param Logger $logger
+	 * @return null
+	 */
+	public function setLogger(Logger $logger)
+	{
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Gets a logger instance
+	 *
+	 * @return Logger
+	 */
+	public function getLogger()
+	{
+		if ( $this->logger === null )
+		{
+			$this->logger = new NullLogger;
+		}
+
+		return $this->logger;
+	}
+}

--- a/src/Logger/NullLogger.php
+++ b/src/Logger/NullLogger.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace YoutubeDownloader\Logger;
+
+/**
+ * a null logger instance, that simply throw all messages away
+ */
+class NullLogger implements Logger
+{
+	/**
+	 * System is unusable.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function emergency($message, array $context = array())
+	{
+		// do nothing
+	}
+
+	/**
+	 * Action must be taken immediately.
+	 *
+	 * Example: Entire website down, database unavailable, etc. This should
+	 * trigger the SMS alerts and wake you up.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function alert($message, array $context = array())
+	{
+		// do nothing
+	}
+
+	/**
+	 * Critical conditions.
+	 *
+	 * Example: Application component unavailable, unexpected exception.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function critical($message, array $context = array())
+	{
+		// do nothing
+	}
+
+	/**
+	 * Runtime errors that do not require immediate action but should typically
+	 * be logged and monitored.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function error($message, array $context = array())
+	{
+		// do nothing
+	}
+
+	/**
+	 * Exceptional occurrences that are not errors.
+	 *
+	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
+	 * that are not necessarily wrong.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function warning($message, array $context = array())
+	{
+		// do nothing
+	}
+
+	/**
+	 * Normal but significant events.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function notice($message, array $context = array())
+	{
+		// do nothing
+	}
+
+	/**
+	 * Interesting events.
+	 *
+	 * Example: User logs in, SQL logs.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function info($message, array $context = array())
+	{
+		// do nothing
+	}
+
+	/**
+	 * Detailed debug information.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function debug($message, array $context = array())
+	{
+		// do nothing
+	}
+
+	/**
+	 * Logs with an arbitrary level.
+	 *
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function log($level, $message, array $context = array())
+	{
+		// do nothing
+	}
+}

--- a/src/VideoInfo.php
+++ b/src/VideoInfo.php
@@ -3,6 +3,8 @@
 namespace YoutubeDownloader;
 
 use YoutubeDownloader\Cache\Cache;
+use YoutubeDownloader\Logger\LoggerAware;
+use YoutubeDownloader\Logger\LoggerAwareTrait;
 
 /**
  * VideoInfo
@@ -128,8 +130,10 @@ use YoutubeDownloader\Cache\Cache;
  * - 'reason',
  * - 'errordetail',
  */
-class VideoInfo
+class VideoInfo implements LoggerAware
 {
+	use LoggerAwareTrait;
+
 	/**
 	 * Creates a VideoInfo from string
 	 *
@@ -243,7 +247,14 @@ class VideoInfo
 				continue;
 			}
 
-			$formats[] = Format::createFromArray($this, $format_info, $config);
+			$format = Format::createFromArray($this, $format_info, $config);
+
+			if ( $format instanceOf LoggerAware )
+			{
+				$format->setLogger($this->getLogger());
+			}
+
+			$formats[] = $format;
 		}
 
 		return $formats;

--- a/tests/Fixture/Logger/Psr3LoggerAdapter.php
+++ b/tests/Fixture/Logger/Psr3LoggerAdapter.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace YoutubeDownloader\Tests\Fixture\Logger;
+
+use Psr\Log\LoggerInterface;
+use YoutubeDownloader\Logger\Logger;
+
+/**
+ * A simple PSR-3 logger as a compatibility proof for the Logger interface
+ */
+class Psr3LoggerAdapter implements LoggerInterface, Logger
+{
+	/**
+	 * @var YoutubeDownloader\Logger\Logger
+	 */
+	private $logger;
+
+	/**
+	 * @param YoutubeDownloader\Logger\Logger $logger
+	 *
+	 * @return void
+	 */
+	public function __construct(Logger $logger)
+	{
+		$this->logger = $logger;
+	}
+
+	/**
+	 * System is unusable.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function emergency($message, array $context = array())
+	{
+		return $this->logger->emergency($message, $context);
+	}
+
+	/**
+	 * Action must be taken immediately.
+	 *
+	 * Example: Entire website down, database unavailable, etc. This should
+	 * trigger the SMS alerts and wake you up.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function alert($message, array $context = array())
+	{
+		return $this->logger->alert($message, $context);
+	}
+
+	/**
+	 * Critical conditions.
+	 *
+	 * Example: Application component unavailable, unexpected exception.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function critical($message, array $context = array())
+	{
+		return $this->logger->critical($message, $context);
+	}
+
+	/**
+	 * Runtime errors that do not require immediate action but should typically
+	 * be logged and monitored.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function error($message, array $context = array())
+	{
+		return $this->logger->error($message, $context);
+	}
+
+	/**
+	 * Exceptional occurrences that are not errors.
+	 *
+	 * Example: Use of deprecated APIs, poor use of an API, undesirable things
+	 * that are not necessarily wrong.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function warning($message, array $context = array())
+	{
+		return $this->logger->warning($message, $context);
+	}
+
+	/**
+	 * Normal but significant events.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function notice($message, array $context = array())
+	{
+		return $this->logger->notice($message, $context);
+	}
+
+	/**
+	 * Interesting events.
+	 *
+	 * Example: User logs in, SQL logs.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function info($message, array $context = array())
+	{
+		return $this->logger->info($message, $context);
+	}
+
+	/**
+	 * Detailed debug information.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function debug($message, array $context = array())
+	{
+		return $this->logger->debug($message, $context);
+	}
+
+	/**
+	 * Logs with an arbitrary level.
+	 *
+	 * @param mixed $level
+	 * @param string $message
+	 * @param array $context
+	 * @return null
+	 */
+	public function log($level, $message, array $context = array())
+	{
+		return $this->logger->log($leverl, $message, $context);
+	}
+}

--- a/tests/Unit/Application/AppTest.php
+++ b/tests/Unit/Application/AppTest.php
@@ -13,7 +13,10 @@ class AppTest extends TestCase
 	 */
 	public function getContainer()
 	{
+		$logger = $this->createMock('\\YoutubeDownloader\\Logger\\Logger');
+
 		$container = $this->createMock('\\YoutubeDownloader\\Container\\Container');
+		$container->method('get')->with('logger')->willReturn($logger);
 
 		$app = new App($container);
 
@@ -25,7 +28,10 @@ class AppTest extends TestCase
 	 */
 	public function getVersion()
 	{
+		$logger = $this->createMock('\\YoutubeDownloader\\Logger\\Logger');
+
 		$container = $this->createMock('\\YoutubeDownloader\\Container\\Container');
+		$container->method('get')->with('logger')->willReturn($logger);
 
 		$app = new App($container);
 
@@ -49,11 +55,13 @@ class AppTest extends TestCase
 			->method('make')
 			->willReturn($controller);
 
+		$logger = $this->createMock('\\YoutubeDownloader\\Logger\\Logger');
+
 		$container = $this->createMock('\\YoutubeDownloader\\Container\\Container');
-		$container->expects($this->once())
-			->method('get')
-			->with('controller_factory')
-			->willReturn($factory);
+		$container->method('get')->will($this->returnValueMap([
+			['controller_factory', $factory],
+			['logger', $logger],
+		]));
 
 		$app = new App($container);
 

--- a/tests/Unit/Application/ControllerFactoryTest.php
+++ b/tests/Unit/Application/ControllerFactoryTest.php
@@ -12,7 +12,13 @@ class ControllerFactoryTest extends TestCase
 	 */
 	public function make()
 	{
+		$logger = $this->createMock('\\YoutubeDownloader\\Logger\\Logger');
+
+		$container = $this->createMock('\\YoutubeDownloader\\Container\\Container');
+		$container->method('get')->with('logger')->willReturn($logger);
+
 		$app = $this->createMock('\\YoutubeDownloader\\Application\\App');
+		$app->method('getContainer')->willReturn($container);
 
 		$factory = new ControllerFactory;
 

--- a/tests/Unit/Logger/Handler/SimpleEntryTest.php
+++ b/tests/Unit/Logger/Handler/SimpleEntryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace YoutubeDownloader\Tests\Unit\Logger\Handler;
+
+use YoutubeDownloader\Logger\Handler\SimpleEntry;
+use YoutubeDownloader\Tests\Fixture\TestCase;
+
+class SimpleEntryTest extends TestCase
+{
+	private $entry;
+
+	/**
+	 * Create a entry
+	 */
+	public function setUp()
+	{
+		$this->entry = new SimpleEntry(
+			new \DateTimeImmutable('now'),
+			'debug',
+			'Log of {description}',
+			['description' => 'a debug message']
+		);
+	}
+
+	/**
+	 * @test SimpleEntry implements Entry
+	 */
+	public function implementsEntry()
+	{
+		$this->assertInstanceOf(
+			'\\YoutubeDownloader\\Logger\\Handler\\Entry',
+			$this->entry
+		);
+	}
+
+	/**
+	 * @test getMessage
+	 */
+	public function getMessage()
+	{
+		$this->assertSame(
+			'Log of {description}',
+			$this->entry->getMessage()
+		);
+	}
+
+	/**
+	 * @test getContext
+	 */
+	public function getContext()
+	{
+		$this->assertSame(
+			['description' => 'a debug message'],
+			$this->entry->getContext()
+		);
+	}
+
+	/**
+	 * @test getLevel
+	 */
+	public function getLevel()
+	{
+		$this->assertSame(
+			'debug',
+			$this->entry->getLevel()
+		);
+	}
+
+	/**
+	 * @test getCreatedAt
+	 */
+	public function getCreatedAt()
+	{
+		$this->assertInstanceOf(
+			'DateTimeImmutable',
+			$this->entry->getCreatedAt()
+		);
+	}
+}

--- a/tests/Unit/Logger/Handler/SimpleEntryTest.php
+++ b/tests/Unit/Logger/Handler/SimpleEntryTest.php
@@ -15,7 +15,7 @@ class SimpleEntryTest extends TestCase
 	public function setUp()
 	{
 		$this->entry = new SimpleEntry(
-			new \DateTimeImmutable('now'),
+			new \DateTime('now'),
 			'debug',
 			'Log of {description}',
 			['description' => 'a debug message']
@@ -72,7 +72,7 @@ class SimpleEntryTest extends TestCase
 	public function getCreatedAt()
 	{
 		$this->assertInstanceOf(
-			'DateTimeImmutable',
+			'DateTime',
 			$this->entry->getCreatedAt()
 		);
 	}

--- a/tests/Unit/Logger/Handler/StreamHandlerTest.php
+++ b/tests/Unit/Logger/Handler/StreamHandlerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace YoutubeDownloader\Tests\Unit\Logger\Handler;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use YoutubeDownloader\Logger\Handler\StreamHandler;
+use YoutubeDownloader\Tests\Fixture\TestCase;
+
+class StreamHandlerTest extends TestCase
+{
+	/**
+	 * @test StreamHandler implements Handler
+	 */
+	public function implementsHandler()
+	{
+		$root = vfsStream::setup('logs');
+		vfsStream::newFile('test.log', 0600)->at($root);
+
+		$stream = fopen('vfs://logs/test.log', 'a+');
+
+		$handler = new StreamHandler($stream, []);
+
+		$this->assertInstanceOf(
+			'\\YoutubeDownloader\\Logger\\Handler\\Handler',
+			$handler
+		);
+	}
+
+	/**
+	 * @test Exception if stream is not writable
+	 */
+	public function expectExceptionWithoutResource()
+	{
+		$stream = new \stdClass;
+
+		$this->expectException('\\Exception');
+		$this->expectExceptionMessage('Parameter 1 must be a resource');
+
+		$handler = new StreamHandler($stream, []);
+	}
+
+	/**
+	 * @test Exception if stream is not writable
+	 */
+	public function expectExceptionWithNotWritableStream()
+	{
+		$root = vfsStream::setup('logs');
+		vfsStream::newFile('test.log', 0600)->at($root);
+
+		$stream = fopen('vfs://logs/test.log', 'r');
+
+		$this->expectException('\\Exception');
+		$this->expectExceptionMessage('The resource must be writable.');
+
+		$handler = new StreamHandler($stream, []);
+	}
+
+	/**
+	 * @test save entry into stream
+	 */
+	public function handleEntry()
+	{
+		$root = vfsStream::setup('logs');
+		vfsStream::newFile('test.log', 0600)->at($root);
+
+		$stream = fopen('vfs://logs/test.log', 'a+');
+
+		$handler = new StreamHandler($stream, ['debug']);
+
+		$entry = $this->createMock('\\YoutubeDownloader\\Logger\\Handler\\Entry');
+		$entry->method('getMessage')->willReturn('Log with {message}.');
+		$entry->method('getContext')->willReturn(['message' => 'a debug message']);
+		$entry->method('getLevel')->willReturn('debug');
+		$entry->method('getCreatedAt')->willReturn(
+			new \DateTimeImmutable('2017-08-22 16:20:40', new \DateTimeZone('UTC'))
+		);
+
+		$this->assertTrue($handler->handles('debug'));
+
+		$handler->handle($entry);
+
+		$this->assertSame(
+			"[2017-08-22T16:20:40+00:00] debug: Log with a debug message.\n",
+			$root->getChild('test.log')->getContent()
+		);
+	}
+}

--- a/tests/Unit/Logger/Handler/StreamHandlerTest.php
+++ b/tests/Unit/Logger/Handler/StreamHandlerTest.php
@@ -73,7 +73,7 @@ class StreamHandlerTest extends TestCase
 		$entry->method('getContext')->willReturn(['message' => 'a debug message']);
 		$entry->method('getLevel')->willReturn('debug');
 		$entry->method('getCreatedAt')->willReturn(
-			new \DateTimeImmutable('2017-08-22 16:20:40', new \DateTimeZone('UTC'))
+			new \DateTime('2017-08-22 16:20:40', new \DateTimeZone('UTC'))
 		);
 
 		$this->assertTrue($handler->handles('debug'));

--- a/tests/Unit/Logger/HandlerAwareLoggerTest.php
+++ b/tests/Unit/Logger/HandlerAwareLoggerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace YoutubeDownloader\Tests\Unit\Logger;
+
+use YoutubeDownloader\Logger\HandlerAwareLogger;
+use YoutubeDownloader\Tests\Fixture\TestCase;
+
+class HandlerAwareLoggerTest extends TestCase
+{
+	/**
+	 * @test HandlerAwareLogger implements Logger
+	 */
+	public function implementsLogger()
+	{
+		$handler = $this->createMock(
+			'\\YoutubeDownloader\\Logger\\Handler\\Handler'
+		);
+		$logger = new HandlerAwareLogger($handler);
+
+		$this->assertInstanceOf('\\YoutubeDownloader\\Logger\\Logger', $logger);
+	}
+
+	/**
+	 * @test all logger methods
+	 *
+	 * @dataProvider LoggerMethodsDataProvider
+	 */
+	public function loggerMethods($method, $message, array $context)
+	{
+		$handler = $this->createMock(
+			'\\YoutubeDownloader\\Logger\\Handler\\Handler'
+		);
+		$handler->method('handles')->with($method)->willReturn(true);
+		$handler->expects($this->once())->method('handle')->willReturn(null);
+
+		$logger = new HandlerAwareLogger($handler);
+
+		$this->assertNull($logger->$method($message, $context));
+	}
+
+	/**
+	 * LoggerMethodsDataProvider
+	 */
+	public function LoggerMethodsDataProvider()
+	{
+		return [
+			[
+				'emergency',
+				'Log of {description}',
+				['description' => 'an emergency'],
+			],
+			[
+				'alert',
+				'Log of {description}',
+				['description' => 'an alert'],
+			],
+			[
+				'critical',
+				'Log of {description}',
+				['description' => 'critical'],
+			],
+			[
+				'error',
+				'Log of {description}',
+				['description' => 'an error'],
+			],
+			[
+				'warning',
+				'Log of {description}',
+				['description' => 'a warning'],
+			],
+			[
+				'notice',
+				'Log of {description}',
+				['description' => 'a notice'],
+			],
+			[
+				'info',
+				'Log of {description}',
+				['description' => 'an info message'],
+			],
+			[
+				'debug',
+				'Log of {description}',
+				['description' => 'a debug message'],
+			],
+		];
+	}
+}

--- a/tests/Unit/Logger/NullLoggerTest.php
+++ b/tests/Unit/Logger/NullLoggerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace YoutubeDownloader\Tests\Unit\Logger;
+
+use YoutubeDownloader\Logger\NullLogger;
+use YoutubeDownloader\Tests\Fixture\TestCase;
+use YoutubeDownloader\Tests\Fixture\Logger\Psr3LoggerAdapter;
+
+class NullLoggerTest extends TestCase
+{
+	/**
+	 * @test NullLogger implements Logger
+	 */
+	public function implementsLogger()
+	{
+		$logger = new NullLogger();
+
+		$this->assertInstanceOf('\\YoutubeDownloader\\Logger\\Logger', $logger);
+	}
+
+	/**
+	 * @test NullLogger is compatible with Psr\Log\LoggerInterface
+	 */
+	public function isPsr3Compatible()
+	{
+		$logger = new NullLogger();
+
+		$adapter = new Psr3LoggerAdapter($logger);
+
+		$this->assertInstanceOf('\\Psr\\Log\\LoggerInterface', $adapter);
+		$this->assertInstanceOf('\\YoutubeDownloader\\Logger\\Logger', $adapter);
+	}
+}


### PR DESCRIPTION
This PR introduces a new PSR-3 compatible Logger. It should be used to log all kind of stuff like warnings, errors or debug data.

I've added the Logger already in the `SignatureDecipher`, but it should used everywhere. The file `Deciphers.log` can be deleted. Logs are stored in the new `/logs` folder and are only created if `debug` in the config is set to `true`.

refs #221 