### PR TITLE
Add CacheAware interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- new `YoutubeDownloader\Cache\CacheAware` interface
+- `YoutubeDownloader\Provider\Youtube\Format` implements `YoutubeDownloader\Cache\CacheAware` interface
+- `YoutubeDownloader\Provider\Youtube\Provider` implements `YoutubeDownloader\Cache\CacheAware` interface
+- `YoutubeDownloader\Provider\Youtube\VideoInfo` implements `YoutubeDownloader\Cache\CacheAware` interface
+
+### Deprecated
+
+- `YoutubeDownloader\Provider\Youtube\VideoInfo::setToCache()` is deprecated since version 0.5, to be removed in 0.6, use `YoutubeDownloader\Provider\Youtube\VideoInfo::getCache()->set()` instead
+- `YoutubeDownloader\Provider\Youtube\VideoInfo::getFromCache()` is deprecated since version 0.5, to be removed in 0.6, use `YoutubeDownloader\Provider\Youtube\VideoInfo::getCache()->get()` instead
+
 ### Removed
 
 - The `YoutubeDownloader\Format` class was removed, use the `YoutubeDownloader\Provider\Youtube\Format` class instead

--- a/src/Application/DownloadController.php
+++ b/src/Application/DownloadController.php
@@ -69,13 +69,17 @@ class DownloadController extends ControllerAbstract
 					$toolkit
 				);
 
-				$video_info = $youtube_provider->provide($url);
-				$video_info->setCache($this->get('cache'));
-
-				if ( $video_info instanceOf \YoutubeDownloader\Logger\LoggerAware )
+				if ( $youtube_provider instanceOf \YoutubeDownloader\Cache\CacheAware )
 				{
-					$video_info->setLogger($this->get('logger'));
+					$youtube_provider->setCache($this->get('cache'));
 				}
+
+				if ( $youtube_provider instanceOf \YoutubeDownloader\Logger\LoggerAware )
+				{
+					$youtube_provider->setLogger($this->get('logger'));
+				}
+
+				$video_info = $youtube_provider->provide($url);
 
 				try
 				{

--- a/src/Application/ResultController.php
+++ b/src/Application/ResultController.php
@@ -33,6 +33,16 @@ class ResultController extends ControllerAbstract
 			$toolkit
 		);
 
+		if ( $youtube_provider instanceOf \YoutubeDownloader\Cache\CacheAware )
+		{
+			$youtube_provider->setCache($this->get('cache'));
+		}
+
+		if ( $youtube_provider instanceOf \YoutubeDownloader\Logger\LoggerAware )
+		{
+			$youtube_provider->setLogger($this->get('logger'));
+		}
+
 		if ( $youtube_provider->provides($my_id) === false )
 		{
 			$this->responseWithErrorMessage('Invalid url');
@@ -52,13 +62,6 @@ class ResultController extends ControllerAbstract
 		];
 
 		$video_info = $youtube_provider->provide($my_id);
-
-		$video_info->setCache($this->get('cache'));
-
-		if ( $video_info instanceOf \YoutubeDownloader\Logger\LoggerAware )
-		{
-			$video_info->setLogger($this->get('logger'));
-		}
 
 		if ($video_info->getStatus() == 'fail')
 		{

--- a/src/Cache/CacheAware.php
+++ b/src/Cache/CacheAware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace YoutubeDownloader\Cache;
+
+/**
+ * Describes a cache-aware instance
+ */
+interface CacheAware
+{
+	/**
+	 * Sets a cache instance on the object
+	 *
+	 * @param Cache $cache
+	 * @return null
+	 */
+	public function setCache(Cache $cache);
+}

--- a/src/Cache/CacheAwareTrait.php
+++ b/src/Cache/CacheAwareTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace YoutubeDownloader\Cache;
+
+/**
+ * Trait for Cache-aware instances
+ */
+trait CacheAwareTrait
+{
+	/**
+	 * @var YoutubeDownloader\Cache\Cache
+	 */
+	private $cache;
+
+	/**
+	 * Sets a cache instance on the object
+	 *
+	 * @param Cache $cache
+	 * @return null
+	 */
+	public function setCache(Cache $cache)
+	{
+		$this->cache = $cache;
+	}
+
+	/**
+	 * Gets a cache instance
+	 *
+	 * @return Cache
+	 */
+	public function getCache()
+	{
+		if ( $this->cache === null )
+		{
+			$this->cache = new NullCache;
+		}
+
+		return $this->cache;
+	}
+}

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace YoutubeDownloader\Cache;
+
+use DateTimeInterface;
+
+/**
+ * A cache instance that does nothing
+ */
+
+class NullCache implements Cache
+{
+	/**
+	 * Fetches a value from the cache.
+	 *
+	 * @param string $key The unique key of this item in the cache.
+	 * @param mixed  $default Default value to return if the key does not exist.
+	 *
+	 * @return mixed The value of the item from the cache, or $default in case of cache miss.
+	 *
+	 * @throws InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function get($key, $default = null)
+	{
+		$this->validateKey($key);
+
+		return $default;
+	}
+
+	/**
+	 * Persists data in the cache, uniquely referenced by a key with an optional expiration TTL time.
+	 *
+	 * @param string $key   The key of the item to store.
+	 * @param mixed $value The value of the item to store, must be serializable.
+	 * @param null|int|DateInterval $ttl Optional. The TTL value of this item. If no value is sent and
+	 * the driver supports TTL then the library may set a default value
+	 * for it or let the driver take care of that.
+	 *
+	 * @return bool True on success and false on failure.
+	 *
+	 * @throws InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function set($key, $value, $ttl = null)
+	{
+		$this->validateKey($key);
+
+		return true;
+	}
+
+	/**
+	 * Delete an item from the cache by its unique key.
+	 *
+	 * @param string $key The unique cache key of the item to delete.
+	 *
+	 * @return bool True if the item was successfully removed. False if there was an error.
+	 *
+	 * @throws InvalidArgumentException
+	 *   MUST be thrown if the $key string is not a legal value.
+	 */
+	public function delete($key)
+	{
+		$this->validateKey($key);
+
+		return true;
+	}
+
+	/**
+	 * @param string $key
+	 *
+	 * @throws InvalidArgumentException
+	 */
+	private function validateKey($key)
+	{
+		if ( ! is_string($key) )
+		{
+			throw new InvalidArgumentException(
+				sprintf('Cache key must be string, "%s" given', gettype($key))
+			);
+		}
+
+		if ( ! isset($key[0]) )
+		{
+			throw new InvalidArgumentException(
+				'Cache key cannot be an empty string'
+			);
+		}
+
+		if ( preg_match('~[^a-zA-Z0-9_\\-$]+~', $key) !== 0 )
+		{
+			throw new InvalidArgumentException(sprintf(
+				'Invalid key: "%s". The key contains one or more not allowed characters, allowed are only %s',
+				$key,
+				'`a-z`, `A-Z`, `0-9`, `_` and `-`'
+			));
+		}
+	}
+}

--- a/src/Provider/Youtube/Format.php
+++ b/src/Provider/Youtube/Format.php
@@ -2,6 +2,8 @@
 
 namespace YoutubeDownloader\Provider\Youtube;
 
+use YoutubeDownloader\Cache\CacheAware;
+use YoutubeDownloader\Cache\CacheAwareTrait;
 use YoutubeDownloader\Logger\LoggerAware;
 use YoutubeDownloader\Logger\LoggerAwareTrait;
 use YoutubeDownloader\VideoInfo\Format as FormatInterface;
@@ -9,8 +11,9 @@ use YoutubeDownloader\VideoInfo\Format as FormatInterface;
 /**
  * a video format
  */
-class Format implements FormatInterface, LoggerAware
+class Format implements FormatInterface, CacheAware, LoggerAware
 {
+	use CacheAwareTrait;
 	use LoggerAwareTrait;
 
 	/**
@@ -122,13 +125,13 @@ class Format implements FormatInterface, LoggerAware
 
 			$cache_key = 'playerscript_' . $playerID;
 
-			$decipherScript = $this->video_info->getFromCache($cache_key);
+			$decipherScript = $this->getCache()->get($cache_key, null);
 
 			if ( $decipherScript === null )
 			{
 				$decipherScript = SignatureDecipher::downloadRawPlayerScript($playerURL);
 
-				$this->video_info->setToCache($cache_key, $decipherScript, 3600*24);
+				$this->getCache()->set($cache_key, $decipherScript, 3600*24);
 			}
 
 			$sig = SignatureDecipher::decipherSignatureWithRawPlayerScript(

--- a/src/Provider/Youtube/Provider.php
+++ b/src/Provider/Youtube/Provider.php
@@ -2,7 +2,11 @@
 
 namespace YoutubeDownloader\Provider\Youtube;
 
+use YoutubeDownloader\Cache\CacheAware;
+use YoutubeDownloader\Cache\CacheAwareTrait;
 use YoutubeDownloader\Config;
+use YoutubeDownloader\Logger\LoggerAware;
+use YoutubeDownloader\Logger\LoggerAwareTrait;
 use YoutubeDownloader\Toolkit;
 use YoutubeDownloader\VideoInfo\Provider as ProviderInterface;
 use YoutubeDownloader\VideoInfo\InvalidInputException;
@@ -10,8 +14,11 @@ use YoutubeDownloader\VideoInfo\InvalidInputException;
 /**
  * Provider instance for Youtube
  */
-final class Provider implements ProviderInterface
+final class Provider implements ProviderInterface, CacheAware, LoggerAware
 {
+	use CacheAwareTrait;
+	use LoggerAwareTrait;
+
 	/**
 	 * Create this Provider from Config and Toolkit
 	 *
@@ -108,6 +115,16 @@ final class Provider implements ProviderInterface
 			$video_info_string,
 			$this->config
 		);
+
+		if ( $video_info instanceOf CacheAware )
+		{
+			$video_info->setCache($this->getCache());
+		}
+
+		if ( $video_info instanceOf LoggerAware )
+		{
+			$video_info->setLogger($this->getLogger());
+		}
 
 		return $video_info;
 	}

--- a/src/Provider/Youtube/VideoInfo.php
+++ b/src/Provider/Youtube/VideoInfo.php
@@ -3,6 +3,8 @@
 namespace YoutubeDownloader\Provider\Youtube;
 
 use YoutubeDownloader\Cache\Cache;
+use YoutubeDownloader\Cache\CacheAware;
+use YoutubeDownloader\Cache\CacheAwareTrait;
 use YoutubeDownloader\Config;
 use YoutubeDownloader\Logger\LoggerAware;
 use YoutubeDownloader\Logger\LoggerAwareTrait;
@@ -132,8 +134,9 @@ use YoutubeDownloader\VideoInfo\VideoInfo as VideoInfoInterface;
  * - 'reason',
  * - 'errordetail',
  */
-class VideoInfo implements VideoInfoInterface, LoggerAware
+class VideoInfo implements VideoInfoInterface, CacheAware, LoggerAware
 {
+	use CacheAwareTrait;
 	use LoggerAwareTrait;
 
 	/**
@@ -148,11 +151,6 @@ class VideoInfo implements VideoInfoInterface, LoggerAware
 
 		return new self($video_info, $config);
 	}
-
-	/**
-	 * @var YoutubeDownloader\Cache\Cache
-	 */
-	private $cache;
 
 	/**
 	 * @var array
@@ -250,6 +248,11 @@ class VideoInfo implements VideoInfoInterface, LoggerAware
 			}
 
 			$format = Format::createFromArray($this, $format_info, $config);
+
+			if ( $format instanceOf CacheAware )
+			{
+				$format->setCache($this->getCache());
+			}
 
 			if ( $format instanceOf LoggerAware )
 			{
@@ -359,18 +362,9 @@ class VideoInfo implements VideoInfoInterface, LoggerAware
 	}
 
 	/**
-	 * Set cache adapter
-	 *
-	 * @param YoutubeDownloader\Cache\Cache $cache
-	 * @return void
-	 */
-	public function setCache(Cache $cache)
-	{
-		$this->cache = $cache;
-	}
-
-	/**
 	 * Get from cache
+	 *
+	 * @deprecated since version 0.5, to be removed in 0.6. Use VideoInfo::getCache()->get() instead
 	 *
 	 * @param string $key
 	 * @param mixed $default
@@ -378,23 +372,15 @@ class VideoInfo implements VideoInfoInterface, LoggerAware
 	 */
 	public function getFromCache($key, $default = null)
 	{
-		if ( $this->cache !== null )
-		{
-			return $this->cache->get($key, $default);
-		}
+		@trigger_error(__METHOD__ . ' is deprecated since version 0.5, to be removed in 0.6. Use VideoInfo::getCache()->get() instead', E_USER_DEPRECATED);
 
-		die('cache not set');
-
-		if ( file_exists('cache/videoinfo_' . $key) )
-		{
-			return file_get_contents('cache/videoinfo_' . $key);
-		}
-
-		return $default;
+		return $this->getCache()->get($key, $default);
 	}
 
 	/**
 	 * Set to cache
+	 *
+	 * @deprecated since version 0.5, to be removed in 0.6. Use VideoInfo::getCache()->set() instead
 	 *
 	 * @param string $key
 	 * @param mixed $value
@@ -403,11 +389,8 @@ class VideoInfo implements VideoInfoInterface, LoggerAware
 	 */
 	public function setToCache($key, $value, $ttl = null)
 	{
-		if ( $this->cache !== null )
-		{
-			return $this->cache->set($key, $value, $ttl);
-		}
+		@trigger_error(__METHOD__ . ' is deprecated since version 0.5, to be removed in 0.6. Use VideoInfo::getCache()->set() instead', E_USER_DEPRECATED);
 
-		return file_put_contents('cache/videoinfo_' . $key, $value);
+		return $this->getCache()->set($key, $value, $ttl);
 	}
 }

--- a/src/Toolkit.php
+++ b/src/Toolkit.php
@@ -3,6 +3,7 @@
 namespace YoutubeDownloader;
 
 use Exception;
+use YoutubeDownloader\VideoInfo\VideoInfo;
 
 /**
  * Toolkit

--- a/tests/Fixture/Cache/DataProviderTrait.php
+++ b/tests/Fixture/Cache/DataProviderTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace YoutubeDownloader\Tests\Fixture\Cache;
+
+/**
+ * Trait that provides data for tests
+ */
+trait DataProviderTrait
+{
+	/**
+	 * InvalidKeyProvider
+	 */
+	public function InvalidKeyProvider()
+	{
+		$exception_name = '\\YoutubeDownloader\\Cache\\InvalidArgumentException';
+
+		return [
+			[null, $exception_name, 'Cache key must be string, "NULL" given'],
+			[true, $exception_name, 'Cache key must be string, "boolean" given'],
+			[123, $exception_name, 'Cache key must be string, "integer" given'],
+			[12.345, $exception_name, 'Cache key must be string, "double" given'],
+			[['key'], $exception_name, 'Cache key must be string, "array" given'],
+			[new \stdClass, $exception_name, 'Cache key must be string, "object" given'],
+		];
+	}
+}

--- a/tests/Unit/Cache/FileCacheTest.php
+++ b/tests/Unit/Cache/FileCacheTest.php
@@ -5,11 +5,14 @@ namespace YoutubeDownloader\Tests\Unit\Cache;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use YoutubeDownloader\Cache\FileCache;
+use YoutubeDownloader\Tests\Fixture\Cache\DataProviderTrait;
 use YoutubeDownloader\Tests\Fixture\Cache\Psr16CacheAdapter;
 use YoutubeDownloader\Tests\Fixture\TestCase;
 
 class FileCacheTest extends TestCase
 {
+	use DataProviderTrait;
+
 	/**
 	 * @test createFromDirectory()
 	 */
@@ -111,6 +114,23 @@ class FileCacheTest extends TestCase
 
 	/**
 	 * @test get()
+	 *
+	 * @dataProvider InvalidKeyProvider
+	 */
+	public function getWithInvalidKeyThrowsException($invalid_key, $exception_name, $message)
+	{
+		$root = vfsStream::setup('cache');
+
+		$cache = FileCache::createFromDirectory($root->url());
+
+		$this->expectException($exception_name);
+		$this->expectExceptionMessage($message);
+
+		$cache->get($invalid_key);
+	}
+
+	/**
+	 * @test get()
 	 */
 	public function getNotExistingReturnsDefault()
 	{
@@ -200,6 +220,23 @@ class FileCacheTest extends TestCase
 	}
 
 	/**
+	 * @test set()
+	 *
+	 * @dataProvider InvalidKeyProvider
+	 */
+	public function setWithInvalidKeyThrowsException($invalid_key, $exception_name, $message)
+	{
+		$root = vfsStream::setup('cache');
+
+		$cache = FileCache::createFromDirectory($root->url());
+
+		$this->expectException($exception_name);
+		$this->expectExceptionMessage($message);
+
+		$cache->set($invalid_key, 'value');
+	}
+
+	/**
 	 * @test delete()
 	 */
 	public function deleteReturnsTrue()
@@ -216,5 +253,22 @@ class FileCacheTest extends TestCase
 
 		$this->assertTrue($cache->delete('key'));
 		$this->assertFalse($root->hasChildren());
+	}
+
+	/**
+	 * @test delete()
+	 *
+	 * @dataProvider InvalidKeyProvider
+	 */
+	public function deleteWithInvalidKeyThrowsException($invalid_key, $exception_name, $message)
+	{
+		$root = vfsStream::setup('cache');
+
+		$cache = FileCache::createFromDirectory($root->url());
+
+		$this->expectException($exception_name);
+		$this->expectExceptionMessage($message);
+
+		$cache->delete($invalid_key);
 	}
 }

--- a/tests/Unit/Cache/NullCacheTest.php
+++ b/tests/Unit/Cache/NullCacheTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace YoutubeDownloader\Tests\Unit\Cache;
+
+use YoutubeDownloader\Cache\NullCache;
+use YoutubeDownloader\Tests\Fixture\Cache\DataProviderTrait;
+use YoutubeDownloader\Tests\Fixture\TestCase;
+
+class NullCacheTest extends TestCase
+{
+	use DataProviderTrait;
+
+	/**
+	 * @test get()
+	 */
+	public function getReturnsDefault()
+	{
+		$cache = new NullCache;
+
+		$this->assertSame('default', $cache->get('key', 'default'));
+	}
+
+	/**
+	 * @test get()
+	 *
+	 * @dataProvider InvalidKeyProvider
+	 */
+	public function getWithInvalidKeyThrowsException($invalid_key, $exception_name, $message)
+	{
+		$cache = new NullCache;
+
+		$this->expectException($exception_name);
+		$this->expectExceptionMessage($message);
+
+		$cache->get($invalid_key);
+	}
+
+	/**
+	 * @test set()
+	 */
+	public function setReturnsTrue()
+	{
+		$cache = new NullCache;
+
+		$this->assertTrue($cache->set('key', 'foobar'));
+
+		// Test that the setted value not returns
+		$this->assertSame('default', $cache->get('key', 'default'));
+	}
+
+	/**
+	 * @test set()
+	 */
+	public function setWithTtlReturnsTrue()
+	{
+		$cache = new NullCache;
+
+		$this->assertTrue($cache->set('key', 'foobar', 3600));
+
+		// Test that the setted value not returns
+		$this->assertSame('default', $cache->get('key', 'default'));
+	}
+
+	/**
+	 * @test set()
+	 *
+	 * @dataProvider InvalidKeyProvider
+	 */
+	public function setWithInvalidKeyThrowsException($invalid_key, $exception_name, $message)
+	{
+		$cache = new NullCache;
+
+		$this->expectException($exception_name);
+		$this->expectExceptionMessage($message);
+
+		$cache->set($invalid_key, 'value');
+	}
+
+	/**
+	 * @test delete()
+	 */
+	public function deleteReturnsTrue()
+	{
+		$cache = new NullCache;
+
+		$this->assertTrue($cache->delete('key'));
+	}
+
+	/**
+	 * @test delete()
+	 *
+	 * @dataProvider InvalidKeyProvider
+	 */
+	public function deleteWithInvalidKeyThrowsException($invalid_key, $exception_name, $message)
+	{
+		$cache = new NullCache;
+
+		$this->expectException($exception_name);
+		$this->expectExceptionMessage($message);
+
+		$cache->delete($invalid_key);
+	}
+}


### PR DESCRIPTION
This PR adds a new `CacheAware` interface and a `CacheAwareTrait` to add the CacheAware methods to any class.

The Youtube Provider implemtes this new interface for a better handling of the `Cache` instance.