### PR TITLE
Create ServiceProvider, improve SimpleContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `YoutubeDownloader\Provider\Youtube\VideoInfo::setToCache()` is deprecated since version 0.5, to be removed in 0.6, use `YoutubeDownloader\Provider\Youtube\VideoInfo::getCache()->set()` instead
 - `YoutubeDownloader\Provider\Youtube\VideoInfo::getFromCache()` is deprecated since version 0.5, to be removed in 0.6, use `YoutubeDownloader\Provider\Youtube\VideoInfo::getCache()->get()` instead
-- `YoutubeDownloader\Container\SimpleContainer::set()` needs an optional Closure as second argument ($value) since version 0.5, to be required in 0.6, provide a Closure as second argument ($value) instead
+- `YoutubeDownloader\Container\SimpleContainer::set()` needs an optional Closure or a string as alias in second argument ($value) since version 0.5, to be required in 0.6, provide a Closure or a string as alias in second argument ($value) instead
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `YoutubeDownloader\Provider\Youtube\VideoInfo::setToCache()` is deprecated since version 0.5, to be removed in 0.6, use `YoutubeDownloader\Provider\Youtube\VideoInfo::getCache()->set()` instead
 - `YoutubeDownloader\Provider\Youtube\VideoInfo::getFromCache()` is deprecated since version 0.5, to be removed in 0.6, use `YoutubeDownloader\Provider\Youtube\VideoInfo::getCache()->get()` instead
+- `YoutubeDownloader\Container\SimpleContainer::set()` needs an optional Closure as second argument ($value) since version 0.5, to be required in 0.6, provide a Closure as second argument ($value) instead
 
 ### Removed
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -38,6 +38,9 @@ spl_autoload_register(function ($class)
 	}
 });
 
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
 /**
  * Closure to create a container class
  */
@@ -59,9 +62,6 @@ $container = call_user_func_array(
 
 		$service_provider = new \YoutubeDownloader\ServiceProvider($config);
 		$service_provider->register($container);
-
-		// Create HttpClient
-		$container->set('httpclient', new \YoutubeDownloader\Http\CurlClient);
 
 		return $container;
 	},

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -57,74 +57,8 @@ $container = call_user_func_array(
 			$config_dir . $custom . '.php'
 		);
 
-		$container->set('config', $config);
-
-		// Create Template\Engine
-		$template = \YoutubeDownloader\Template\Engine::createFromDirectory(
-			__DIR__ . DIRECTORY_SEPARATOR . 'templates'
-		);
-
-		$container->set('template', $template);
-
-		// Create Application\ControllerFactory
-		$factory = new \YoutubeDownloader\Application\ControllerFactory;
-
-		$container->set('controller_factory', $factory);
-
-		// Create Toolkit
-		$container->set('toolkit', new \YoutubeDownloader\Toolkit);
-
-		// Create Cache
-		$cache = \YoutubeDownloader\Cache\FileCache::createFromDirectory(
-			__DIR__ . DIRECTORY_SEPARATOR . 'cache'
-		);
-
-		$container->set('cache', $cache);
-
-		// Create Logger
-		$logger = new \YoutubeDownloader\Logger\HandlerAwareLogger(
-			new \YoutubeDownloader\Logger\Handler\NullHandler()
-		);
-
-		if ( $config->get('debug') === true )
-		{
-			# code...
-			$now = new \DateTime('now', new \DateTimeZone($config->get('default_timezone')));
-
-			$filepath = sprintf(
-				'%s' . \DIRECTORY_SEPARATOR . '%s',
-				__DIR__ . \DIRECTORY_SEPARATOR . 'logs',
-				$now->format('Y')
-			);
-
-			if ( ! file_exists($filepath) )
-			{
-				mkdir($filepath);
-			}
-
-			$stream = fopen(
-				$filepath . \DIRECTORY_SEPARATOR . $now->format('Y-m-d') . '.log',
-				'a+'
-			);
-
-			if ( is_resource($stream) )
-			{
-				$handler = new \YoutubeDownloader\Logger\Handler\StreamHandler($stream, [
-					\YoutubeDownloader\Logger\LogLevel::EMERGENCY,
-					\YoutubeDownloader\Logger\LogLevel::ALERT,
-					\YoutubeDownloader\Logger\LogLevel::CRITICAL,
-					\YoutubeDownloader\Logger\LogLevel::ERROR,
-					\YoutubeDownloader\Logger\LogLevel::WARNING,
-					\YoutubeDownloader\Logger\LogLevel::NOTICE,
-					\YoutubeDownloader\Logger\LogLevel::INFO,
-					\YoutubeDownloader\Logger\LogLevel::DEBUG,
-				]);
-
-				$logger->addHandler($handler);
-			}
-		}
-
-		$container->set('logger', $logger);
+		$service_provider = new \YoutubeDownloader\ServiceProvider($config);
+		$service_provider->register($container);
 
 		return $container;
 	},

--- a/src/Application/ControllerAbstract.php
+++ b/src/Application/ControllerAbstract.php
@@ -72,7 +72,7 @@ abstract class ControllerAbstract implements Controller
 
 		$options = ['curl' => []];
 		$options['curl'][CURLOPT_NOBODY] = true;
-		$options['curl'][CURLOPT_TIMEOUT] = 1;
+		$options['curl'][CURLOPT_TIMEOUT] = 3;
 		$options['curl'][CURLOPT_SSL_VERIFYPEER] = false;
 
 		if ( $config->get('multipleIPs') === true)

--- a/src/Container/SimpleContainer.php
+++ b/src/Container/SimpleContainer.php
@@ -2,6 +2,8 @@
 
 namespace YoutubeDownloader\Container;
 
+use Closure;
+
 /**
  * A simple container implementation with a setter
  */
@@ -41,7 +43,9 @@ class SimpleContainer implements Container
 			$id = $this->aliases[$id];
 		}
 
-		return $this->data[$id];
+		$closure = $this->data[$id];
+
+		return $closure->__invoke($this);
 	}
 
 	/**
@@ -73,8 +77,22 @@ class SimpleContainer implements Container
 	/**
 	 * Set an entry with an identifier
 	 *
+	 * @deprecated SimpleContainer::set() needs an optional Closure as argument #2 ($value) since version 0.5, to be required in 0.6. Provide a Closure as argument #2 ($value) instead
+	 *
+	 * The second argument for $value must be a Closure that expects the
+	 * Container as first argument. That allows to get entries from the Container
+	 * inside the Closure to build complex dependencies.
+	 *
+	 * Example:
+	 * $value = function(Container $c) {
+	 *   return new LoggerCacheBrige(
+	 *     $c->get('logger'),
+	 *     $c->get('cache')
+	 *   );
+	 * };
+	 *
 	 * @param string $id Identifier of the entry to look for.
-	 * @param mixed $value the entry
+	 * @param Closure $value A closure that returns the entry on invoke
 	 *
 	 * @return void
 	 */
@@ -82,7 +100,21 @@ class SimpleContainer implements Container
 	{
 		$id = strval($id);
 
-		$this->data[$id] = $value;
+		// BC: Create Closure if not provided
+		if ( ! $value instanceOf Closure )
+		{
+			trigger_error(__METHOD__ . ' needs an optional Closure as argument #2 ($value) since version 0.5, to be required in 0.6. Provide a Closure as argument #2 ($value) instead', E_USER_DEPRECATED);
+
+			$val = function(Container $c) use ($value) {
+				return $value;
+			};
+		}
+		else
+		{
+			$val = $value;
+		}
+
+		$this->data[$id] = $val;
 	}
 
 	/**

--- a/src/Container/SimpleContainer.php
+++ b/src/Container/SimpleContainer.php
@@ -77,7 +77,7 @@ class SimpleContainer implements Container
 	/**
 	 * Set an entry with an identifier
 	 *
-	 * @deprecated SimpleContainer::set() needs an optional Closure as argument #2 ($value) since version 0.5, to be required in 0.6. Provide a Closure as argument #2 ($value) instead
+	 * @deprecated SimpleContainer::set() needs an optional Closure or a string as alias in argument #2 ($value) since version 0.5, to be required in 0.6. Provide a Closure as argument #2 ($value) instead
 	 *
 	 * The second argument for $value must be a Closure that expects the
 	 * Container as first argument. That allows to get entries from the Container
@@ -92,7 +92,7 @@ class SimpleContainer implements Container
 	 * };
 	 *
 	 * @param string $id Identifier of the entry to look for.
-	 * @param Closure $value A closure that returns the entry on invoke
+	 * @param Closure|string $value A closure that returns the entry on invoke or an identifier that a reference to an existing entry
 	 *
 	 * @return void
 	 */
@@ -100,10 +100,16 @@ class SimpleContainer implements Container
 	{
 		$id = strval($id);
 
+		// BC: String can be an alias for an entry
+		if ( is_string($value) and array_key_exists($value, $this->data) )
+		{
+			return $this->setAlias($id, $value);
+		}
+
 		// BC: Create Closure if not provided
 		if ( ! $value instanceOf Closure )
 		{
-			@trigger_error(__METHOD__ . ' needs an optional Closure as argument #2 ($value) since version 0.5, to be required in 0.6. Provide a Closure as argument #2 ($value) instead', E_USER_DEPRECATED);
+			@trigger_error(__METHOD__ . ' needs an optional Closure or a string as alias in argument #2 ($value) since version 0.5, to be required in 0.6. Provide a Closure or a string as alias in argument #2 ($value) instead', E_USER_DEPRECATED);
 
 			$val = function(Container $c) use ($value) {
 				return $value;
@@ -125,7 +131,7 @@ class SimpleContainer implements Container
 	 *
 	 * @return void
 	 */
-	public function setAlias($alias, $id)
+	private function setAlias($alias, $id)
 	{
 		$id = strval($id);
 		$alias = strval($alias);

--- a/src/Container/SimpleContainer.php
+++ b/src/Container/SimpleContainer.php
@@ -103,7 +103,7 @@ class SimpleContainer implements Container
 		// BC: Create Closure if not provided
 		if ( ! $value instanceOf Closure )
 		{
-			trigger_error(__METHOD__ . ' needs an optional Closure as argument #2 ($value) since version 0.5, to be required in 0.6. Provide a Closure as argument #2 ($value) instead', E_USER_DEPRECATED);
+			@trigger_error(__METHOD__ . ' needs an optional Closure as argument #2 ($value) since version 0.5, to be required in 0.6. Provide a Closure as argument #2 ($value) instead', E_USER_DEPRECATED);
 
 			$val = function(Container $c) use ($value) {
 				return $value;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -30,74 +30,80 @@ class ServiceProvider
 	{
 		$ds = \DIRECTORY_SEPARATOR;
 
-		$container->set('YoutubeDownloader\Config', $this->config);
+		$container->set('YoutubeDownloader\Config', function($c) {
+			return $this->config;
+		});
 
 		// Create Template\Engine
-		$template = \YoutubeDownloader\Template\Engine::createFromDirectory(
-			__DIR__ . $ds . '..' . $ds . 'templates'
-		);
-
-		$container->set('YoutubeDownloader\Template\Engine', $template);
+		$container->set('YoutubeDownloader\Template\Engine', function($c) {
+			return \YoutubeDownloader\Template\Engine::createFromDirectory(
+				__DIR__ . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . 'templates'
+			);
+		});
 
 		// Create Application\ControllerFactory
-		$factory = new \YoutubeDownloader\Application\ControllerFactory;
-
-		$container->set('YoutubeDownloader\Application\ControllerFactory', $factory);
+		$container->set('YoutubeDownloader\Application\ControllerFactory', function($c) {
+			return new \YoutubeDownloader\Application\ControllerFactory;
+		});
 
 		// Create Toolkit
-		$container->set('YoutubeDownloader\Toolkit', new \YoutubeDownloader\Toolkit);
+		$container->set('YoutubeDownloader\Toolkit', function($c) {
+			return new \YoutubeDownloader\Toolkit;
+		});
 
 		// Create Cache
-		$cache = \YoutubeDownloader\Cache\FileCache::createFromDirectory(
-			__DIR__ . $ds . '..' . $ds . 'cache'
-		);
-
-		$container->set('YoutubeDownloader\Cache\Cache', $cache);
+		$container->set('YoutubeDownloader\Cache\Cache', function($c) {
+			return \YoutubeDownloader\Cache\FileCache::createFromDirectory(
+				__DIR__ . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . 'cache'
+			);
+		});
 
 		// Create Logger
-		$logger = new \YoutubeDownloader\Logger\HandlerAwareLogger(
-			new \YoutubeDownloader\Logger\Handler\NullHandler()
-		);
-
-		if ( $this->config->get('debug') === true )
-		{
-			# code...
-			$now = new \DateTime('now', new \DateTimeZone($this->config->get('default_timezone')));
-
-			$filepath = sprintf(
-				'%s' . $ds . '%s',
-				__DIR__ . $ds . '..' . $ds . 'logs',
-				$now->format('Y')
+		$container->set('YoutubeDownloader\Logger\Logger', function($c) {
+			$logger = new \YoutubeDownloader\Logger\HandlerAwareLogger(
+				new \YoutubeDownloader\Logger\Handler\NullHandler()
 			);
 
-			if ( ! file_exists($filepath) )
+			if ( $c->get('YoutubeDownloader\Config')->get('debug') === true )
 			{
-				mkdir($filepath);
+				# code...
+				$now = new \DateTime('now', new \DateTimeZone($c->get('YoutubeDownloader\Config')->get('default_timezone')));
+
+				$filepath = sprintf(
+					'%s' . \DIRECTORY_SEPARATOR . '%s',
+					__DIR__ . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . 'logs',
+					$now->format('Y')
+				);
+
+				if ( ! file_exists($filepath) )
+				{
+					mkdir($filepath);
+				}
+
+				$stream = fopen(
+					$filepath . \DIRECTORY_SEPARATOR . '..' . \DIRECTORY_SEPARATOR . $now->format('Y-m-d') . '.log',
+					'a+'
+				);
+
+				if ( is_resource($stream) )
+				{
+					$handler = new \YoutubeDownloader\Logger\Handler\StreamHandler($stream, [
+						\YoutubeDownloader\Logger\LogLevel::EMERGENCY,
+						\YoutubeDownloader\Logger\LogLevel::ALERT,
+						\YoutubeDownloader\Logger\LogLevel::CRITICAL,
+						\YoutubeDownloader\Logger\LogLevel::ERROR,
+						\YoutubeDownloader\Logger\LogLevel::WARNING,
+						\YoutubeDownloader\Logger\LogLevel::NOTICE,
+						\YoutubeDownloader\Logger\LogLevel::INFO,
+						\YoutubeDownloader\Logger\LogLevel::DEBUG,
+					]);
+
+					$logger->addHandler($handler);
+				}
 			}
 
-			$stream = fopen(
-				$filepath . $ds . '..' . $ds . $now->format('Y-m-d') . '.log',
-				'a+'
-			);
-
-			if ( is_resource($stream) )
-			{
-				$handler = new \YoutubeDownloader\Logger\Handler\StreamHandler($stream, [
-					\YoutubeDownloader\Logger\LogLevel::EMERGENCY,
-					\YoutubeDownloader\Logger\LogLevel::ALERT,
-					\YoutubeDownloader\Logger\LogLevel::CRITICAL,
-					\YoutubeDownloader\Logger\LogLevel::ERROR,
-					\YoutubeDownloader\Logger\LogLevel::WARNING,
-					\YoutubeDownloader\Logger\LogLevel::NOTICE,
-					\YoutubeDownloader\Logger\LogLevel::INFO,
-					\YoutubeDownloader\Logger\LogLevel::DEBUG,
-				]);
-
-				$logger->addHandler($handler);
-			}
-		}
-
-		$container->set('YoutubeDownloader\Logger\Logger', $logger);
+			return $logger;
+		});
 
 		// Set aliases for BC
 		$container->setAlias('config', 'YoutubeDownloader\Config');

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -106,11 +106,11 @@ class ServiceProvider
 		});
 
 		// Set aliases for BC
-		$container->setAlias('config', 'YoutubeDownloader\Config');
-		$container->setAlias('template', 'YoutubeDownloader\Template\Engine');
-		$container->setAlias('controller_factory', 'YoutubeDownloader\Application\ControllerFactory');
-		$container->setAlias('toolkit', 'YoutubeDownloader\Toolkit');
-		$container->setAlias('cache', 'YoutubeDownloader\Cache\Cache');
-		$container->setAlias('logger', 'YoutubeDownloader\Logger\Logger');
+		$container->set('config', 'YoutubeDownloader\Config');
+		$container->set('template', 'YoutubeDownloader\Template\Engine');
+		$container->set('controller_factory', 'YoutubeDownloader\Application\ControllerFactory');
+		$container->set('toolkit', 'YoutubeDownloader\Toolkit');
+		$container->set('cache', 'YoutubeDownloader\Cache\Cache');
+		$container->set('logger', 'YoutubeDownloader\Logger\Logger');
 	}
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -105,6 +105,11 @@ class ServiceProvider
 			return $logger;
 		});
 
+		// Create HttpClient
+		$container->set('YoutubeDownloader\Http\Client', function($c) {
+			return new \YoutubeDownloader\Http\CurlClient;
+		});
+
 		// Set aliases for BC
 		$container->set('config', 'YoutubeDownloader\Config');
 		$container->set('template', 'YoutubeDownloader\Template\Engine');
@@ -112,5 +117,6 @@ class ServiceProvider
 		$container->set('toolkit', 'YoutubeDownloader\Toolkit');
 		$container->set('cache', 'YoutubeDownloader\Cache\Cache');
 		$container->set('logger', 'YoutubeDownloader\Logger\Logger');
+		$container->set('httpclient', 'YoutubeDownloader\Http\Client');
 	}
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -30,29 +30,29 @@ class ServiceProvider
 	{
 		$ds = \DIRECTORY_SEPARATOR;
 
-		$container->set('config', $this->config);
+		$container->set('YoutubeDownloader\Config', $this->config);
 
 		// Create Template\Engine
 		$template = \YoutubeDownloader\Template\Engine::createFromDirectory(
 			__DIR__ . $ds . '..' . $ds . 'templates'
 		);
 
-		$container->set('template', $template);
+		$container->set('YoutubeDownloader\Template\Engine', $template);
 
 		// Create Application\ControllerFactory
 		$factory = new \YoutubeDownloader\Application\ControllerFactory;
 
-		$container->set('controller_factory', $factory);
+		$container->set('YoutubeDownloader\Application\ControllerFactory', $factory);
 
 		// Create Toolkit
-		$container->set('toolkit', new \YoutubeDownloader\Toolkit);
+		$container->set('YoutubeDownloader\Toolkit', new \YoutubeDownloader\Toolkit);
 
 		// Create Cache
 		$cache = \YoutubeDownloader\Cache\FileCache::createFromDirectory(
 			__DIR__ . $ds . '..' . $ds . 'cache'
 		);
 
-		$container->set('cache', $cache);
+		$container->set('YoutubeDownloader\Cache\Cache', $cache);
 
 		// Create Logger
 		$logger = new \YoutubeDownloader\Logger\HandlerAwareLogger(
@@ -97,6 +97,14 @@ class ServiceProvider
 			}
 		}
 
-		$container->set('logger', $logger);
+		$container->set('YoutubeDownloader\Logger\Logger', $logger);
+
+		// Set aliases for BC
+		$container->setAlias('config', 'YoutubeDownloader\Config');
+		$container->setAlias('template', 'YoutubeDownloader\Template\Engine');
+		$container->setAlias('controller_factory', 'YoutubeDownloader\Application\ControllerFactory');
+		$container->setAlias('toolkit', 'YoutubeDownloader\Toolkit');
+		$container->setAlias('cache', 'YoutubeDownloader\Cache\Cache');
+		$container->setAlias('logger', 'YoutubeDownloader\Logger\Logger');
 	}
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace YoutubeDownloader;
+
+use YoutubeDownloader\Container\SimpleContainer;
+
+/**
+ * ServiceProvider class
+ */
+class ServiceProvider
+{
+	private $config;
+
+	/**
+	 * @param Config $config
+	 * @return self
+	 */
+	public function __construct(Config $config)
+	{
+		$this->config = $config;
+	}
+
+	/**
+	 * Register the Services on a Container
+	 *
+	 * @param SimpleContainer $container
+	 * @return void
+	 */
+	public function register(SimpleContainer $container)
+	{
+		$ds = \DIRECTORY_SEPARATOR;
+
+		$container->set('config', $this->config);
+
+		// Create Template\Engine
+		$template = \YoutubeDownloader\Template\Engine::createFromDirectory(
+			__DIR__ . $ds . '..' . $ds . 'templates'
+		);
+
+		$container->set('template', $template);
+
+		// Create Application\ControllerFactory
+		$factory = new \YoutubeDownloader\Application\ControllerFactory;
+
+		$container->set('controller_factory', $factory);
+
+		// Create Toolkit
+		$container->set('toolkit', new \YoutubeDownloader\Toolkit);
+
+		// Create Cache
+		$cache = \YoutubeDownloader\Cache\FileCache::createFromDirectory(
+			__DIR__ . $ds . '..' . $ds . 'cache'
+		);
+
+		$container->set('cache', $cache);
+
+		// Create Logger
+		$logger = new \YoutubeDownloader\Logger\HandlerAwareLogger(
+			new \YoutubeDownloader\Logger\Handler\NullHandler()
+		);
+
+		if ( $this->config->get('debug') === true )
+		{
+			# code...
+			$now = new \DateTime('now', new \DateTimeZone($this->config->get('default_timezone')));
+
+			$filepath = sprintf(
+				'%s' . $ds . '%s',
+				__DIR__ . $ds . '..' . $ds . 'logs',
+				$now->format('Y')
+			);
+
+			if ( ! file_exists($filepath) )
+			{
+				mkdir($filepath);
+			}
+
+			$stream = fopen(
+				$filepath . $ds . '..' . $ds . $now->format('Y-m-d') . '.log',
+				'a+'
+			);
+
+			if ( is_resource($stream) )
+			{
+				$handler = new \YoutubeDownloader\Logger\Handler\StreamHandler($stream, [
+					\YoutubeDownloader\Logger\LogLevel::EMERGENCY,
+					\YoutubeDownloader\Logger\LogLevel::ALERT,
+					\YoutubeDownloader\Logger\LogLevel::CRITICAL,
+					\YoutubeDownloader\Logger\LogLevel::ERROR,
+					\YoutubeDownloader\Logger\LogLevel::WARNING,
+					\YoutubeDownloader\Logger\LogLevel::NOTICE,
+					\YoutubeDownloader\Logger\LogLevel::INFO,
+					\YoutubeDownloader\Logger\LogLevel::DEBUG,
+				]);
+
+				$logger->addHandler($handler);
+			}
+		}
+
+		$container->set('logger', $logger);
+	}
+}

--- a/tests/Unit/Container/SimpleContainerTest.php
+++ b/tests/Unit/Container/SimpleContainerTest.php
@@ -35,7 +35,7 @@ class SimpleContainerTest extends TestCase
 	 * @test set(), has() and get()
 	 * @dataProvider GetterSetterProvider
 	 */
-	public function testSetterAndGetter($id, $value)
+	public function testSetterAndGetterForBC($id, $value)
 	{
 		$container = new SimpleContainer();
 
@@ -43,6 +43,43 @@ class SimpleContainerTest extends TestCase
 
 		$this->assertTrue($container->has($id));
 		$this->assertSame($value, $container->get($id));
+	}
+
+	/**
+	 * @test set(), has() and get()
+	 * @dataProvider GetterSetterProvider
+	 */
+	public function testSetterAndGetter($id, $value)
+	{
+		$container = new SimpleContainer();
+
+		$closure = function($c) use ($value) {
+			return $value;
+		};
+
+		$container->set($id, $closure);
+
+		$this->assertTrue($container->has($id));
+		$this->assertSame($value, $container->get($id));
+	}
+
+	/**
+	 * @test set(), has() and get()
+	 * @dataProvider GetterSetterProvider
+	 */
+	public function testSetterAndGetterAlias($id, $value)
+	{
+		$container = new SimpleContainer();
+
+		$closure = function($c) use ($value) {
+			return $value;
+		};
+
+		$container->set($id, $closure);
+		$container->set($id . '-alias', $id);
+
+		$this->assertTrue($container->has($id.'-alias'));
+		$this->assertSame($value, $container->get($id.'-alias'));
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces a new ServiceProvider that holds all instance creation from the bootstrap. As a bonus I've improved the SimpleContainer accept a Closure on `set()` that will only invoke if this entry is called with `get()`. This will only instantiate classes if they are needed.

refs #251.

This PR will create conflicts if #256 is merged first. I will resolve this conflicts if they appears.