### PR TITLE
Add GPL2 notice to all PHP files

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 /**
  * PSR-4 autoloader
  *

--- a/download.php
+++ b/download.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 $app = include_once('bootstrap.php');
 
 $app->runWithRoute('download');

--- a/getimage.php
+++ b/getimage.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 $app = include_once('bootstrap.php');
 
 $app->runWithRoute('image');

--- a/getvideo.php
+++ b/getvideo.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 $app = include_once('bootstrap.php');
 
 $app->runWithRoute('results');

--- a/index.php
+++ b/index.php
@@ -1,4 +1,23 @@
 <?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 $app = include_once('bootstrap.php');
 
 $app->runWithRoute('index');

--- a/src/Application/App.php
+++ b/src/Application/App.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Application;
 
 use YoutubeDownloader\Container\Container;

--- a/src/Application/Controller.php
+++ b/src/Application/Controller.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Application;
 
 /**

--- a/src/Application/ControllerAbstract.php
+++ b/src/Application/ControllerAbstract.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Application;
 
 /**

--- a/src/Application/ControllerFactory.php
+++ b/src/Application/ControllerFactory.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Application;
 
 use Exception;

--- a/src/Application/DownloadController.php
+++ b/src/Application/DownloadController.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Application;
 
 use Exception;

--- a/src/Application/ImageController.php
+++ b/src/Application/ImageController.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Application;
 
 /**

--- a/src/Application/MainController.php
+++ b/src/Application/MainController.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Application;
 
 /**

--- a/src/Application/ResultController.php
+++ b/src/Application/ResultController.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Application;
 
 use YoutubeDownloader\VideoInfo\VideoInfo;

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 /**

--- a/src/Cache/CacheAware.php
+++ b/src/Cache/CacheAware.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 /**

--- a/src/Cache/CacheAwareTrait.php
+++ b/src/Cache/CacheAwareTrait.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 /**

--- a/src/Cache/CacheException.php
+++ b/src/Cache/CacheException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 use Exception;

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 use DateTimeInterface;

--- a/src/Cache/InvalidArgumentException.php
+++ b/src/Cache/InvalidArgumentException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 /**

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 use DateTimeInterface;

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader;
 
 /**

--- a/src/Container/Container.php
+++ b/src/Container/Container.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Container;
 
 /**

--- a/src/Container/ContainerException.php
+++ b/src/Container/ContainerException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Container;
 
 use Exception;

--- a/src/Container/NotFoundException.php
+++ b/src/Container/NotFoundException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Container;
 
 /**

--- a/src/Container/SimpleContainer.php
+++ b/src/Container/SimpleContainer.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Container;
 
 use Closure;

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http;
 
 use YoutubeDownloader\Http\Message\Request as RequestInterface;

--- a/src/Http/CurlClient.php
+++ b/src/Http/CurlClient.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http;
 
 use YoutubeDownloader\Http\Message\Request as RequestInterface;

--- a/src/Http/HttpClientAware.php
+++ b/src/Http/HttpClientAware.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http;
 
 /**

--- a/src/Http/HttpClientAwareTrait.php
+++ b/src/Http/HttpClientAwareTrait.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http;
 
 /**

--- a/src/Http/Message/Message.php
+++ b/src/Http/Message/Message.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http\Message;
 
 /**

--- a/src/Http/Message/Request.php
+++ b/src/Http/Message/Request.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http\Message;
 
 /**

--- a/src/Http/Message/Response.php
+++ b/src/Http/Message/Response.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http\Message;
 
 /**

--- a/src/Http/Message/ServerRequest.php
+++ b/src/Http/Message/ServerRequest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http\Message;
 
 /**

--- a/src/Http/MessageTrait.php
+++ b/src/Http/MessageTrait.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http;
 
 use InvalidArgumentException;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http;
 
 use YoutubeDownloader\Http\Message\Request as RequestInterface;

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Http;
 
 use YoutubeDownloader\Http\Message\Response as ResponseInterface;

--- a/src/Logger/Handler/Entry.php
+++ b/src/Logger/Handler/Entry.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger\Handler;
 
 /**

--- a/src/Logger/Handler/Handler.php
+++ b/src/Logger/Handler/Handler.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger\Handler;
 
 /**

--- a/src/Logger/Handler/NullHandler.php
+++ b/src/Logger/Handler/NullHandler.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger\Handler;
 
 /**

--- a/src/Logger/Handler/SimpleEntry.php
+++ b/src/Logger/Handler/SimpleEntry.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger\Handler;
 
 use DateTime;

--- a/src/Logger/Handler/StreamHandler.php
+++ b/src/Logger/Handler/StreamHandler.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger\Handler;
 
 /**

--- a/src/Logger/HandlerAwareLogger.php
+++ b/src/Logger/HandlerAwareLogger.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger;
 
 use DateTime;

--- a/src/Logger/LogLevel.php
+++ b/src/Logger/LogLevel.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger;
 
 /**

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger;
 
 /**

--- a/src/Logger/LoggerAware.php
+++ b/src/Logger/LoggerAware.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger;
 
 /**

--- a/src/Logger/LoggerAwareTrait.php
+++ b/src/Logger/LoggerAwareTrait.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger;
 
 /**

--- a/src/Logger/NullLogger.php
+++ b/src/Logger/NullLogger.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Logger;
 
 /**

--- a/src/Provider/Youtube/Format.php
+++ b/src/Provider/Youtube/Format.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Provider\Youtube;
 
 use YoutubeDownloader\Cache\CacheAware;

--- a/src/Provider/Youtube/Provider.php
+++ b/src/Provider/Youtube/Provider.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Provider\Youtube;
 
 use YoutubeDownloader\Cache\CacheAware;

--- a/src/Provider/Youtube/SignatureDecipher.php
+++ b/src/Provider/Youtube/SignatureDecipher.php
@@ -1,4 +1,22 @@
 <?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
 // Because we will processing 1MB of file I will not use RegExp for processing strings
 
 namespace YoutubeDownloader\Provider\Youtube;

--- a/src/Provider/Youtube/VideoInfo.php
+++ b/src/Provider/Youtube/VideoInfo.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Provider\Youtube;
 
 use YoutubeDownloader\Cache\Cache;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader;
 
 use YoutubeDownloader\Container\SimpleContainer;

--- a/src/Template/Engine.php
+++ b/src/Template/Engine.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Template;
 
 /**

--- a/src/Template/Template.php
+++ b/src/Template/Template.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Template;
 
 use Exception;

--- a/src/Toolkit.php
+++ b/src/Toolkit.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader;
 
 use Exception;

--- a/src/VideoInfo/Exception.php
+++ b/src/VideoInfo/Exception.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\VideoInfo;
 
 use RuntimeException;

--- a/src/VideoInfo/Format.php
+++ b/src/VideoInfo/Format.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\VideoInfo;
 
 /**

--- a/src/VideoInfo/InvalidInputException.php
+++ b/src/VideoInfo/InvalidInputException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\VideoInfo;
 
 /**

--- a/src/VideoInfo/Provider.php
+++ b/src/VideoInfo/Provider.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\VideoInfo;
 
 /**

--- a/src/VideoInfo/VideoInfo.php
+++ b/src/VideoInfo/VideoInfo.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\VideoInfo;
 
 /**

--- a/tests/Fixture/Cache/DataProviderTrait.php
+++ b/tests/Fixture/Cache/DataProviderTrait.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture\Cache;
 
 /**

--- a/tests/Fixture/Cache/Psr16CacheAdapter.php
+++ b/tests/Fixture/Cache/Psr16CacheAdapter.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture\Cache;
 
 use Psr\SimpleCache\CacheInterface;

--- a/tests/Fixture/Cache/Psr16CacheException.php
+++ b/tests/Fixture/Cache/Psr16CacheException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 use Exception;

--- a/tests/Fixture/Cache/Psr16InvalidArgumentException.php
+++ b/tests/Fixture/Cache/Psr16InvalidArgumentException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Cache;
 
 use Psr\SimpleCache\InvalidArgumentException;

--- a/tests/Fixture/Container/Psr11ContainerAdapter.php
+++ b/tests/Fixture/Container/Psr11ContainerAdapter.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture\Container;
 
 use Psr\Container\ContainerExceptionInterface;

--- a/tests/Fixture/Container/Psr11ContainerException.php
+++ b/tests/Fixture/Container/Psr11ContainerException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Container;
 
 use Exception;

--- a/tests/Fixture/Container/Psr11NotFoundException.php
+++ b/tests/Fixture/Container/Psr11NotFoundException.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Container;
 
 use Psr\Container\NotFoundExceptionInterface;

--- a/tests/Fixture/Http/Message.php
+++ b/tests/Fixture/Http/Message.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture\Http;
 
 use YoutubeDownloader\Http\MessageTrait;

--- a/tests/Fixture/Http/Psr7MessageAdapter.php
+++ b/tests/Fixture/Http/Psr7MessageAdapter.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture\Http;
 
 use Psr\Http\Message\MessageInterface;

--- a/tests/Fixture/Http/Psr7RequestAdapter.php
+++ b/tests/Fixture/Http/Psr7RequestAdapter.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture\Http;
 
 use Psr\Http\Message\RequestInterface;

--- a/tests/Fixture/Http/Psr7ResponseAdapter.php
+++ b/tests/Fixture/Http/Psr7ResponseAdapter.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture\Http;
 
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Fixture/Logger/Psr3LoggerAdapter.php
+++ b/tests/Fixture/Logger/Psr3LoggerAdapter.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture\Logger;
 
 use Psr\Log\LoggerInterface;

--- a/tests/Fixture/TestCase.php
+++ b/tests/Fixture/TestCase.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Fixture;
 
 class TestCase extends \PHPUnit\Framework\TestCase

--- a/tests/Unit/Application/AppTest.php
+++ b/tests/Unit/Application/AppTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Application;
 
 use YoutubeDownloader\Application\App;

--- a/tests/Unit/Application/ControllerFactoryTest.php
+++ b/tests/Unit/Application/ControllerFactoryTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Application;
 
 use YoutubeDownloader\Application\ControllerFactory;

--- a/tests/Unit/Cache/FileCacheTest.php
+++ b/tests/Unit/Cache/FileCacheTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Cache;
 
 use org\bovigo\vfs\vfsStream;

--- a/tests/Unit/Cache/NullCacheTest.php
+++ b/tests/Unit/Cache/NullCacheTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Cache;
 
 use YoutubeDownloader\Cache\NullCache;

--- a/tests/Unit/Container/SimpleContainerTest.php
+++ b/tests/Unit/Container/SimpleContainerTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Container;
 
 use YoutubeDownloader\Container\SimpleContainer;

--- a/tests/Unit/Http/MessageTraitTest.php
+++ b/tests/Unit/Http/MessageTraitTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Cache;
 
 use YoutubeDownloader\Http\MessageTrait;

--- a/tests/Unit/Http/RequestTest.php
+++ b/tests/Unit/Http/RequestTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Cache;
 
 use YoutubeDownloader\Http\Request;

--- a/tests/Unit/Http/ResponseTest.php
+++ b/tests/Unit/Http/ResponseTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Cache;
 
 use YoutubeDownloader\Http\Response;

--- a/tests/Unit/Logger/Handler/SimpleEntryTest.php
+++ b/tests/Unit/Logger/Handler/SimpleEntryTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Logger\Handler;
 
 use YoutubeDownloader\Logger\Handler\SimpleEntry;

--- a/tests/Unit/Logger/Handler/StreamHandlerTest.php
+++ b/tests/Unit/Logger/Handler/StreamHandlerTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Logger\Handler;
 
 use org\bovigo\vfs\vfsStream;

--- a/tests/Unit/Logger/HandlerAwareLoggerTest.php
+++ b/tests/Unit/Logger/HandlerAwareLoggerTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Logger;
 
 use YoutubeDownloader\Logger\HandlerAwareLogger;

--- a/tests/Unit/Logger/NullLoggerTest.php
+++ b/tests/Unit/Logger/NullLoggerTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Logger;
 
 use YoutubeDownloader\Logger\NullLogger;

--- a/tests/Unit/Provider/Youtube/FormatTest.php
+++ b/tests/Unit/Provider/Youtube/FormatTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Provider\Youtube;
 
 use YoutubeDownloader\Provider\Youtube\Format;

--- a/tests/Unit/Provider/Youtube/ProviderTest.php
+++ b/tests/Unit/Provider/Youtube/ProviderTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Provider\Youtube;
 
 use YoutubeDownloader\Provider\Youtube\Provider;

--- a/tests/Unit/Provider/Youtube/VideoInfoTest.php
+++ b/tests/Unit/Provider/Youtube/VideoInfoTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Provider\Youtube;
 
 use YoutubeDownloader\Provider\Youtube\VideoInfo;

--- a/tests/Unit/Template/EngineTest.php
+++ b/tests/Unit/Template/EngineTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Template;
 
 use org\bovigo\vfs\vfsStream;

--- a/tests/Unit/Template/TemplateTest.php
+++ b/tests/Unit/Template/TemplateTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit\Template;
 
 use org\bovigo\vfs\vfsStream;

--- a/tests/Unit/ToolkitTest.php
+++ b/tests/Unit/ToolkitTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace YoutubeDownloader\Tests\Unit;
 
 use YoutubeDownloader\Toolkit;


### PR DESCRIPTION
This PR simply adds a GPL2 notice in every PHP file like it is recommended in the [LICENSE](https://github.com/jeckman/YouTube-Downloader/blob/master/LICENSE#L288) file:

> To do so, attach the following notices to the program.  It is safest
> to attach them to the start of each source file to most effectively
> convey the exclusion of warranty; and each file should have at least
> the "copyright" line and a pointer to where the full notice is found.

I've added this notice into nearly every PHP file.

```
/*
 * PHP script for downloading videos from youtube
 * Copyright (C) 2012-2017  John Eckman
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
 * (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License along
 * with this program; if not, see <http://www.gnu.org/licenses/>.
 */
```

What do you think?