### PR TITLE
Rewrite config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- `YoutubeDownloader\Provider\Youtube\Provider::createFromOptions()` to create the Youtube Provider with an options array
-- `YoutubeDownloader\Provider\Youtube\VideoInfo::createFromStringWithOptions()` to create the Youtube VideoInfo with an options array
+- new `YoutubeDownloader\Config\TransformationConfig` for a BC friendly configuraion
+- new `YoutubeDownloader\Provider\Youtube\Provider::createFromOptions()` to create the Youtube Provider with an options array
+- new `YoutubeDownloader\Provider\Youtube\VideoInfo::createFromStringWithOptions()` to create the Youtube VideoInfo with an options array
 
 ### Changed
 
 - The mp3 downloader was improved and has no dependendy to aria2 anymore
+- Moved configuration `$config['ThumbnailImageMode']` to `$config['gui']['ThumbnailImageMode']`
+- Moved configuration `$config['VideoLinkMode']` to `$config['gui']['VideoLinkMode']`
+- Moved configuration `$config['showBrowserExtensions']` to `$config['gui']['showBrowserExtensions']`
 
 ### Deprecated
 
+- `YoutubeDownloader\Config` will be removed in 0.7, use `YoutubeDownloader\Config\TransformationConfig` instead
 - `YoutubeDownloader\Provider\Youtube\Provider::createFromConfigAndToolkit()` will be removed in 0.7, use `YoutubeDownloader\Provider\Youtube\Provider::createFromOptions()` instead
 - `YoutubeDownloader\Provider\Youtube\VideoInfo::createFromStringWithConfig()` will be removed in 0.7, use `YoutubeDownloader\Provider\Youtube\VideoInfo::createFromStringWithOptions()` instead
 - `YoutubeDownloader\Toolkit::validateVideoId()` isn't used anymore and will be removed in 0.7

--- a/config/default.php
+++ b/config/default.php
@@ -6,152 +6,148 @@
  * Instead copy this file to `config/custom.php` and make your changes there!
  */
 
-return [
-    /**
-     * Debug mode
-     * WARNING: This outputs debug information while processing.
-     * This could leak sensitive server data to the browser.
-     * Enable only if needed.
-     *
-     * true   => debug mode on
-     * false  => debug mode off
-     */
-    'debug' => false,
+/**
+ * Debug mode
+ * WARNING: This outputs debug information while processing.
+ * This could leak sensitive server data to the browser.
+ * Enable only if needed.
+ *
+ * true  => debug mode on
+ * false => debug mode off
+ */
+$config['debug'] = false;
 
-    /**
-     * Enable the YouTube signature decipher function
-     * WARNING: This downloads javascript code from a 3rd party server and interprets it!
-     * This MAY harm your server, if the 3rd party server delivers malicious code!
-     *
-     * false => decipher is disabled
-     * true => decipher is enabled
-     */
-    'enable_youtube_decipher_signature' => false,
+/**
+ * Enable the YouTube signature decipher function
+ * WARNING: This downloads javascript code from a 3rd party server and interprets it!
+ * This MAY harm your server, if the 3rd party server delivers malicious code!
+ *
+ * false => decipher is disabled
+ * true  => decipher is enabled
+ */
+$config['enable_youtube_decipher_signature'] = false;
 
-    /**
-     * Thumbnail Image Configuration
-     *
-     * 0 => don't show thumbnail image
-     * 1 => show thumbnail image directly from YouTube
-     * 2 => show thumbnail image by proxy from this server
-     */
-    'ThumbnailImageMode' => 2,
+/**
+ * Thumbnail Image Configuration
+ *
+ * 0 => don't show thumbnail image
+ * 1 => show thumbnail image directly from YouTube
+ * 2 => show thumbnail image by proxy from this server
+ */
+$config['ThumbnailImageMode'] = 2;
 
-    /**
-     * Video Download Link Configuration
-     * 'direct' => show only direct download link
-     * 'proxy'  => show only by proxy download link
-     * 'both'   => show both direct and by proxy download links
-     */
-    'VideoLinkMode' => 'both',
+/**
+ * Video Download Link Configuration
+ * 'direct' => show only direct download link
+ * 'proxy'  => show only by proxy download link
+ * 'both'   => show both direct and by proxy download links
+ */
+$config['VideoLinkMode'] = 'both';
 
-    /**
-     * MP3 Download Link Configuration
-     *
-     * Basic method for converting Youtube Video or Audio to .mp3
-     * require server processing for running ffmpeg and aria2, also you may need to edit php "max_execution_time"
-     *
-     * FFMPEG for converting video or audio to .mp3
-     * Install: https://ffmpeg.org/download.html
-     *
-     * ARIA2 command line downloader with multi connection, using single connection (ffmpeg or curl) server download from youtube limited to 56KBps
-     * install: https://github.com/aria2/aria2/releases
-     *
-     */
-    'MP3Enable' => false, // enable or disable media conversion and download to mp3
-    'MP3ConvertVideo' => false, // 'false' download adaptive audio only to save bandwidth.
-    // 'true' failover to video download if adaptive audio format not available
-    'MP3Quality' => '128k', // 'number(k)' (64k, 80k, 96k, 112k, 128k, 160k, 192k) or 'high': bitrate quality of converted mp3
-    // set to 'high' to get and set highest quality
-    // info: highest Youtube audio bitrate is 160k, higher than that is maybe useless
-    'MP3TempDir' => realpath(__DIR__ . '/../cache/'), // temporary download location for media
-    'ffmpegPath' => 'C:\Program Files (x86)\ffmpeg\ffmpeg.exe', // ffmpeg location path
-    'aria2Path' => 'C:\cygwin\bin\aria2c.exe', // aria2 location path, @deprecated since 0.6, to be removed in 0.7
+/**
+ * MP3 Download Link Configuration
+ *
+ * Basic method for converting Youtube Video or Audio to .mp3
+ * require server processing for running ffmpeg and aria2, also you may need to edit php "max_execution_time"
+ *
+ * FFMPEG for converting video or audio to .mp3
+ * Install: https://ffmpeg.org/download.html
+ *
+ * ARIA2 command line downloader with multi connection, using single connection (ffmpeg or curl) server download from youtube limited to 56KBps
+ * install: https://github.com/aria2/aria2/releases
+ */
+$config['MP3Enable'] = false; // enable or disable media conversion and download to mp3
+$config['MP3ConvertVideo'] = false; // 'false' download adaptive audio only to save bandwidth.
+// 'true' failover to video download if adaptive audio format not available
+$config['MP3Quality'] = '128k'; // 'number(k)' (64k, 80k, 96k, 112k, 128k, 160k, 192k) or 'high': bitrate quality of converted mp3
+// set to 'high' to get and set highest quality
+// info: highest Youtube audio bitrate is 160k, higher than that is maybe useless
+$config['MP3TempDir'] = realpath(__DIR__ . '/../cache/'); // temporary download location for media
+$config['ffmpegPath'] = 'C:\Program Files (x86)\ffmpeg\ffmpeg.exe'; // ffmpeg location path
+$config['aria2Path'] = 'C:\cygwin\bin\aria2c.exe'; // aria2 location path, @deprecated since 0.6, to be removed in 0.7
 
-    /**
-     * show links for install browser extensions?
-     *
-     * true or false
-     */
-    'showBrowserExtensions' => true,
+/**
+ * show links for install browser extensions?
+ *
+ * true or false
+ */
+$config['showBrowserExtensions'] = true;
 
-    /**
-     * Multiple IPs
-     *
-     * You can enable this option if you are having problems with youtube IP limit / IP ban.
-     * This option will work only if the IP you add are available for the server.
-     * That means you have to buy some additionnal public IPs and assign these new static IPs to the server.
-     * This should work only if you have a dedicated server...
-     *
-     *
-     * Example of adding additional IPs to Ubuntu server 14.04 LTS
-     * !!!! Be very careful, you may block yourself !!!!
-     * !!!! If you are connecting to your server remotly by ssh. You would do this only if you know what you do !!!!
-     * !!!! This is only an example with a specific dedicated server (ovh.net) !!!!
-     *
-     * For this example, the main IP on the server is 123.456.789.001
-     * We want to add additionnal IPs 789.456.123.001 and 789.456.123.002
-     *
-     * Edit /etc/network/interfaces and put something like this:
-     *
-     * # The loopback network interface
-     * auto lo
-     * iface lo inet loopback
-     *
-     * # The Main server IP:
-     * auto eth0
-     * iface eth0 inet static
-     *     address 123.456.789.001
-     *     netmask 255.255.255.0
-     *     network 123.456.789.0
-     *     broadcast 123.456.789.255
-     *     gateway 123.456.789.254
-     *
-     * # Additionnal IP: 789.456.123.001
-     * auto eth0:0
-     * iface eth0:0 inet static
-     *     address 789.456.123.001
-     *     netmask 255.255.255.255
-     *     broadcast 789.456.123.001
-     *     gateway 123.456.789.254
-     *
-     * # Additionnal IP: 789.456.123.002
-     * auto eth0:1
-     * iface eth0:0 inet static
-     *     address 789.456.123.002
-     *     netmask 255.255.255.255
-     *     broadcast 789.456.123.002
-     *     gateway 123.456.789.254
-     *
-     * # Additionnal IP xxx.xxx.xxx.xxx
-     * auto eth0:2
-     * iface eth0:2 inet static
-     * (...)
-     *
-     * and so on for each IP you want to add....
-     *
-     *
-     * Reboot your server
-     * If you are having trouble and cannot connect anymore over ssh to your server,
-     * that means your new network configuration has errors...
-     * So be very careful before applying your configuration.
-     * Try it first on a local dev server before messing up with your pro server.
-     *
-     *
-     */
-    'multipleIPs' => false, // enable multiple IPs support to bypass Youtube IP limit? true or false
-    'IPs' => [
-        //'xxx.xxx.xxx.xxx',
-        //'xxx.xxx.xxx.xxx',
-        // add as many ips as you want (they must be available in the server conf (ex: /etc/network/interfaces fro ubuntu/debian)
-    ],
+/**
+ * Multiple IPs
+ *
+ * You can enable this option if you are having problems with youtube IP limit / IP ban.
+ * This option will work only if the IP you add are available for the server.
+ * That means you have to buy some additionnal public IPs and assign these new static IPs to the server.
+ * This should work only if you have a dedicated server...
+ *
+ * Example of adding additional IPs to Ubuntu server 14.04 LTS
+ * !!!! Be very careful, you may block yourself !!!!
+ * !!!! If you are connecting to your server remotly by ssh. You would do this only if you know what you do !!!!
+ * !!!! This is only an example with a specific dedicated server (ovh.net) !!!!
+ *
+ * For this example, the main IP on the server is 123.456.789.001
+ * We want to add additionnal IPs 789.456.123.001 and 789.456.123.002
+ *
+ * Edit /etc/network/interfaces and put something like this:
+ *
+ * # The loopback network interface
+ * auto lo
+ * iface lo inet loopback
+ *
+ * # The Main server IP:
+ * auto eth0
+ * iface eth0 inet static
+ *     address 123.456.789.001
+ *     netmask 255.255.255.0
+ *     network 123.456.789.0
+ *     broadcast 123.456.789.255
+ *     gateway 123.456.789.254
+ *
+ * # Additionnal IP: 789.456.123.001
+ * auto eth0:0
+ * iface eth0:0 inet static
+ *     address 789.456.123.001
+ *     netmask 255.255.255.255
+ *     broadcast 789.456.123.001
+ *     gateway 123.456.789.254
+ *
+ * # Additionnal IP: 789.456.123.002
+ * auto eth0:1
+ * iface eth0:0 inet static
+ *     address 789.456.123.002
+ *     netmask 255.255.255.255
+ *     broadcast 789.456.123.002
+ *     gateway 123.456.789.254
+ *
+ * # Additionnal IP xxx.xxx.xxx.xxx
+ * auto eth0:2
+ * iface eth0:2 inet static
+ * (...)
+ *
+ * and so on for each IP you want to add....
+ *
+ * Reboot your server
+ * If you are having trouble and cannot connect anymore over ssh to your server,
+ * that means your new network configuration has errors...
+ * So be very careful before applying your configuration.
+ * Try it first on a local dev server before messing up with your pro server.
+ */
+$config['multipleIPs'] = false; // enable multiple IPs support to bypass Youtube IP limit? true or false
 
-    /**
-     * Set your default timezone
-     *
-     * e.g. Asia/Tehran or America/New_York
-     *
-     * more examples: http://php.net/manual/en/timezones.php
-     */
-    'default_timezone' => 'UTC',
+// add as many ips as you want (they must be available in the server conf (ex: /etc/network/interfaces fro ubuntu/debian)
+$config['IPs'] = [
+    //'xxx.xxx.xxx.xxx',
+    //'xxx.xxx.xxx.xxx',
 ];
+
+/**
+ * Set your default timezone
+ *
+ * e.g. Asia/Tehran or America/New_York
+ *
+ * more examples: http://php.net/manual/en/timezones.php
+ */
+$config['default_timezone'] = 'UTC';
+
+return $config;

--- a/config/default.php
+++ b/config/default.php
@@ -30,11 +30,11 @@ $config['enable_youtube_decipher_signature'] = false;
 /**
  * Thumbnail Image Configuration
  *
- * 0 => don't show thumbnail image
- * 1 => show thumbnail image directly from YouTube
- * 2 => show thumbnail image by proxy from this server
+ * 'none' => don't show thumbnail image
+ * 'direct' => show thumbnail image directly from YouTube
+ * 'proxy' => show thumbnail image by proxy from this server
  */
-$config['ThumbnailImageMode'] = 2;
+$config['gui']['ThumbnailImageMode'] = 'proxy';
 
 /**
  * Video Download Link Configuration
@@ -42,7 +42,14 @@ $config['ThumbnailImageMode'] = 2;
  * 'proxy'  => show only by proxy download link
  * 'both'   => show both direct and by proxy download links
  */
-$config['VideoLinkMode'] = 'both';
+$config['gui']['VideoLinkMode'] = 'both';
+
+/**
+ * show links for install browser extensions?
+ *
+ * true or false
+ */
+$config['gui']['showBrowserExtensions'] = true;
 
 /**
  * MP3 Download Link Configuration
@@ -65,13 +72,6 @@ $config['MP3Quality'] = '128k'; // 'number(k)' (64k, 80k, 96k, 112k, 128k, 160k,
 $config['MP3TempDir'] = realpath(__DIR__ . '/../cache/'); // temporary download location for media
 $config['ffmpegPath'] = 'C:\Program Files (x86)\ffmpeg\ffmpeg.exe'; // ffmpeg location path
 $config['aria2Path'] = 'C:\cygwin\bin\aria2c.exe'; // aria2 location path, @deprecated since 0.6, to be removed in 0.7
-
-/**
- * show links for install browser extensions?
- *
- * true or false
- */
-$config['showBrowserExtensions'] = true;
 
 /**
  * Multiple IPs

--- a/src/Application/DownloadController.php
+++ b/src/Application/DownloadController.php
@@ -21,7 +21,7 @@
 namespace YoutubeDownloader\Application;
 
 use Exception;
-use YoutubeDownloader\Config;
+use YoutubeDownloader\Config\Config;
 use YoutubeDownloader\VideoInfo\VideoInfo;
 
 /**
@@ -57,8 +57,10 @@ class DownloadController extends ControllerAbstract
 		// Fetch and serve
 		if ($url)
 		{
+			$gui_config = $config->get('gui');
+
 			// prevent unauthorized download
-			if($config->get('VideoLinkMode') === "direct" and !isset($_GET['getmp3']))
+			if($gui_config['VideoLinkMode'] === "direct" and !isset($_GET['getmp3']))
 			{
 				$this->responseWithErrorMessage(
 					'VideoLinkMode: proxy download not enabled'
@@ -66,7 +68,7 @@ class DownloadController extends ControllerAbstract
 			}
 
 			if(
-				$config->get('VideoLinkMode') !== "direct"
+				$gui_config['VideoLinkMode'] !== 'direct'
 				and ! isset($_GET['getmp3'])
 				and ! preg_match('@https://[^\.]+\.googlevideo.com/@', $url)
 			)

--- a/src/Application/MainController.php
+++ b/src/Application/MainController.php
@@ -38,9 +38,11 @@ class MainController extends ControllerAbstract
 		$config = $this->get('config');
 		$template = $this->get('template');
 
+		$gui_config = $config->get('gui');
+
 		echo $template->render('index.php', [
 			'app_version' => $this->getAppVersion(),
-			'showBrowserExtensions' => ($this->isUseragentChrome($_SERVER['HTTP_USER_AGENT']) and $config->get('showBrowserExtensions')),
+			'showBrowserExtensions' => ($this->isUseragentChrome($_SERVER['HTTP_USER_AGENT']) and $gui_config['showBrowserExtensions']),
 		]);
 	}
 }

--- a/src/Application/ResultController.php
+++ b/src/Application/ResultController.php
@@ -105,19 +105,21 @@ class ResultController extends ControllerAbstract
 			exit;
 		}
 
-		switch ($config->get('ThumbnailImageMode'))
+		$gui_config = $config->get('gui');
+
+		switch ($gui_config['ThumbnailImageMode'])
 		{
-			case 2:
+			case 'proxy':
 				$template_data['show_thumbnail'] = true;
 				$template_data['thumbnail_src'] = 'getimage.php?videoid=' . $my_id;
 				$template_data['thumbnail_anchor'] = 'getimage.php?videoid=' . $my_id . '&sz=hd';
 				break;
-			case 1:
+			case 'direct':
 				$template_data['show_thumbnail'] = true;
 				$template_data['thumbnail_src'] = $video_info->getThumbnailUrl();
 				$template_data['thumbnail_anchor'] = 'getimage.php?videoid=' . $my_id . '&sz=hd';
 				break;
-			case 0:
+			case 'none':
 			default:
 				$template_data['show_thumbnail'] = false;
 		}
@@ -159,9 +161,11 @@ class ResultController extends ControllerAbstract
 			$template_data['debug2_ipbits'] = $first_format->getIpbits();
 		}
 
+		$gui_config = $config->get('gui');
+
 		$template_data['streams'] = [];
 		$template_data['formats'] = [];
-		$template_data['showBrowserExtensions'] = ( $this->isUseragentChrome($_SERVER['HTTP_USER_AGENT']) and $config->get('showBrowserExtensions') == true );
+		$template_data['showBrowserExtensions'] = ( $this->isUseragentChrome($_SERVER['HTTP_USER_AGENT']) and $gui_config['showBrowserExtensions'] == true );
 
 		/* now that we have the array, print the options */
 		foreach ($avail_formats as $avail_format)
@@ -176,8 +180,8 @@ class ResultController extends ControllerAbstract
 			$size = $this->getSize($avail_format->getUrl(), $config, $toolkit);
 
 			$template_data['streams'][] = [
-				'show_direct_url' => ($config->get('VideoLinkMode') === 'direct' || $config->get('VideoLinkMode') === 'both'),
-				'show_proxy_url' => ($config->get('VideoLinkMode') === 'proxy' || $config->get('VideoLinkMode') === 'both'),
+				'show_direct_url' => ($gui_config['VideoLinkMode'] === 'direct' || $gui_config['VideoLinkMode'] === 'both'),
+				'show_proxy_url' => ($gui_config['VideoLinkMode'] === 'proxy' || $gui_config['VideoLinkMode'] === 'both'),
 				'direct_url' => $directlink,
 				'proxy_url' => $proxylink,
 				'type' => $avail_format->getType(),
@@ -198,8 +202,8 @@ class ResultController extends ControllerAbstract
 			$size = $this->getSize($avail_format->getUrl(), $config, $toolkit);
 
 			$template_data['formats'][] = [
-				'show_direct_url' => ($config->get('VideoLinkMode') === 'direct' || $config->get('VideoLinkMode') === 'both'),
-				'show_proxy_url' => ($config->get('VideoLinkMode') === 'proxy' || $config->get('VideoLinkMode') === 'both'),
+				'show_direct_url' => ($gui_config['VideoLinkMode'] === 'direct' || $gui_config['VideoLinkMode'] === 'both'),
+				'show_proxy_url' => ($gui_config['VideoLinkMode'] === 'proxy' || $gui_config['VideoLinkMode'] === 'both'),
 				'direct_url' => $directlink,
 				'proxy_url' => $proxylink,
 				'type' => $avail_format->getType(),

--- a/src/Config.php
+++ b/src/Config.php
@@ -20,6 +20,10 @@
 
 namespace YoutubeDownloader;
 
+use YoutubeDownloader\Config\Config as ConfigInterface;
+use YoutubeDownloader\Config\FileLoader;
+use YoutubeDownloader\Config\TransformationConfig;
+
 /**
  * Config class
  */
@@ -34,53 +38,32 @@ class Config
 	 */
 	public static function createFromFiles($default, $custom = null)
 	{
-		$default_config = require($default);
-		$custom_config = [];
+		$args = [new FileLoader($default)];
 
-		if ( file_exists($custom) )
+		if ( $custom !== null )
 		{
-			$custom_config = require($custom);
+			$args[] = new FileLoader($custom);
 		}
 
-		$config = array_replace_recursive($default_config, $custom_config);
+		$config = call_user_func_array(
+			[TransformationConfig::class, 'createFromLoaders'],
+			$args
+		);
 
 		return new self($config);
 	}
 
-	private $data = [];
-
-	private $allowed_keys = [
-		'enable_youtube_decipher_signature',
-		'ThumbnailImageMode',
-		'VideoLinkMode',
-		'MP3Enable',
-		'MP3ConvertVideo',
-		'MP3Quality',
-		'MP3TempDir',
-		'ffmpegPath',
-		'aria2Path',
-		'showBrowserExtensions',
-		'multipleIPs',
-		'IPs',
-		'default_timezone',
-		'debug',
-	];
+	private $config;
 
 	/**
-	 * Creates a Config from an array
+	 * Creates a Config from another config
 	 *
 	 * @param array $config
 	 * @return self
 	 */
-	private function __construct(array $config)
+	private function __construct(ConfigInterface $config)
 	{
-		foreach ($this->allowed_keys as $key)
-		{
-			if ( array_key_exists($key, $config) )
-			{
-				$this->data[$key] = $config[$key];
-			}
-		}
+		$this->config = $config;
 	}
 
 	/**
@@ -91,11 +74,6 @@ class Config
 	 */
 	public function get($key)
 	{
-		if ( array_key_exists($key, $this->data) )
-		{
-			return $this->data[$key];
-		}
-
-		throw new \InvalidArgumentException;
+		return $this->config->get($key);
 	}
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -20,14 +20,18 @@
 
 namespace YoutubeDownloader;
 
+@trigger_error('The '.__NAMESPACE__.'\Config class is deprecated since version 0.6 and will be removed in 0.7. Use the YoutubeDownloader\Config\TransformationConfig class instead.', E_USER_DEPRECATED);
+
 use YoutubeDownloader\Config\Config as ConfigInterface;
 use YoutubeDownloader\Config\FileLoader;
 use YoutubeDownloader\Config\TransformationConfig;
 
 /**
  * Config class
+ *
+ * @deprecated since version 0.6, to be removed in 0.7. Use `YoutubeDownloader\Config\TransformationConfig` instead
  */
-class Config
+class Config implements ConfigInterface
 {
 	/**
 	 * Creates the config from files

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace YoutubeDownloader\Config;
+
+/**
+ * interface for Config class
+ */
+interface Config
+{
+	/**
+	 * Get a config value
+	 *
+	 * @throws \InvalidArgumentException if argument $key don't exists
+	 *
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function get($key);
+}

--- a/src/Config/FileLoader.php
+++ b/src/Config/FileLoader.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace YoutubeDownloader\Config;
+
+/**
+ * config loader from file
+ */
+class FileLoader implements Loader
+{
+	private $config;
+
+	/**
+	 * Loads the config from a file
+	 *
+	 * @param string $path
+	 * @return array
+	 */
+	public function __construct($path)
+	{
+		$path = (string) $path;
+
+		if ( ! file_exists($path) )
+		{
+			throw new \Exception(sprintf(
+				'Config file %s must exist and must be readable.',
+				$path
+			));
+		}
+
+		$config = require($path);
+
+		if ( ! is_array($config) )
+		{
+			throw new \Exception(sprintf(
+				'Config file %s must return an array.',
+				$path
+			));
+		}
+
+		$this->config = $config;
+	}
+
+	/**
+	 * export the config as array
+	 *
+	 * @return array
+	 */
+	public function exportAsArray()
+	{
+		return $this->config;
+	}
+}

--- a/src/Config/Loader.php
+++ b/src/Config/Loader.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace YoutubeDownloader\Config;
+
+/**
+ * interface for config loader
+ */
+interface Loader
+{
+	/**
+	 * export the config as array
+	 *
+	 * @return array
+	 */
+	public function exportAsArray();
+}

--- a/src/Config/TransformationConfig.php
+++ b/src/Config/TransformationConfig.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * PHP script for downloading videos from youtube
+ * Copyright (C) 2012-2017  John Eckman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace YoutubeDownloader\Config;
+
+/**
+ * Config class with build-in transformator for deprecated configs
+ */
+class TransformationConfig implements Config
+{
+	/**
+	 * Creates the config from Loaders
+	 *
+	 * @param Loader $default the default config
+	 * @param Loader $custom the custom config
+	 * @return Config
+	 */
+	public static function createFromLoaders(Loader $default, Loader $custom = null)
+	{
+		$custom_config = [];
+
+		if ( $custom !== null )
+		{
+			$custom_config = $custom->exportAsArray();
+		}
+
+		return new self($default->exportAsArray(), $custom_config);
+	}
+
+	private $data = [];
+
+	private $warnings = [];
+
+	/**
+	 * Creates a Config from two arrays
+	 *
+	 * @param array $default
+	 * @param array $custom
+	 * @return self
+	 */
+	private function __construct(array $default, array $custom)
+	{
+		$default = $this->transform($default, $custom);
+
+		$config = $this->merge($default, $custom);
+
+		$this->data = $config;
+	}
+
+	/**
+	 * Transform deprecated custom configuration into the default configuration
+	 *
+	 * @param array $default
+	 * @param array $custom
+	 * @return array The transformed $default array
+	 */
+	private function transform(array $default, array $custom)
+	{
+		// @deprecated since 0.6: ThumbnailImageMode => gui.ThumbnailImageMode
+		if ( array_key_exists('ThumbnailImageMode', $custom) )
+		{
+			$default['gui']['ThumbnailImageMode'] = $custom['ThumbnailImageMode'];
+			$this->warnings[] = '$config[\'ThumbnailImageMode\'] is deprecated, use $config[\'gui\'][\'ThumbnailImageMode\'] instead';
+		}
+
+		// @deprecated since 0.6: VideoLinkMode => gui.VideoLinkMode
+		if ( array_key_exists('VideoLinkMode', $custom) )
+		{
+			$default['gui']['VideoLinkMode'] = $custom['VideoLinkMode'];
+			$this->warnings[] = '$config[\'VideoLinkMode\'] is deprecated, use $config[\'gui\'][\'VideoLinkMode\'] instead';
+		}
+
+		// @deprecated since 0.6: showBrowserExtensions => gui.showBrowserExtensions
+		if ( array_key_exists('showBrowserExtensions', $custom) )
+		{
+			$default['gui']['showBrowserExtensions'] = $custom['showBrowserExtensions'];
+			$this->warnings[] = '$config[\'showBrowserExtensions\'] is deprecated, use $config[\'gui\'][\'showBrowserExtensions\'] instead';
+		}
+
+		return $default;
+	}
+
+	/**
+	 * merge two configuration arrays
+	 *
+	 * @param array $default
+	 * @param array $custom
+	 * @return self
+	 */
+	private function merge(array $default, array $custom)
+	{
+		foreach ($default as $key => $value)
+		{
+			if ( ! array_key_exists($key, $custom) )
+			{
+				continue;
+			}
+
+			if ( is_array($value) and ! empty($value) )
+			{
+				$default[$key] = $this->merge($value, $custom[$key]);
+
+				continue;
+			}
+
+			$default[$key] = $custom[$key];
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Get a config value
+	 *
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function get($key)
+	{
+		if ( array_key_exists($key, $this->data) )
+		{
+			return $this->data[$key];
+		}
+
+		throw new \InvalidArgumentException(sprintf(
+			'The key "" don\' exist in this Config',
+			(string) $key
+		));
+	}
+}

--- a/src/Config/TransformationConfig.php
+++ b/src/Config/TransformationConfig.php
@@ -76,7 +76,23 @@ class TransformationConfig implements Config
 		// @deprecated since 0.6: ThumbnailImageMode => gui.ThumbnailImageMode
 		if ( array_key_exists('ThumbnailImageMode', $custom) )
 		{
-			$default['gui']['ThumbnailImageMode'] = $custom['ThumbnailImageMode'];
+			switch ($custom['ThumbnailImageMode'])
+			{
+				case 0:
+					$value = 'none';
+					break;
+
+				case 1:
+					$value = 'direct';
+					break;
+
+				case 2:
+				default:
+					$value = 'proxy';
+					break;
+			}
+
+			$default['gui']['ThumbnailImageMode'] = $value;
 			$this->warnings[] = '$config[\'ThumbnailImageMode\'] is deprecated, use $config[\'gui\'][\'ThumbnailImageMode\'] instead';
 		}
 

--- a/src/Provider/Youtube/Provider.php
+++ b/src/Provider/Youtube/Provider.php
@@ -22,7 +22,7 @@ namespace YoutubeDownloader\Provider\Youtube;
 
 use YoutubeDownloader\Cache\CacheAware;
 use YoutubeDownloader\Cache\CacheAwareTrait;
-use YoutubeDownloader\Config;
+use YoutubeDownloader\Config\Config;
 use YoutubeDownloader\Http\HttpClientAware;
 use YoutubeDownloader\Http\HttpClientAwareTrait;
 use YoutubeDownloader\Logger\LoggerAware;
@@ -76,7 +76,7 @@ final class Provider implements ProviderInterface, CacheAware, HttpClientAware, 
 	}
 
 	/**
-	 * @var YoutubeDownloader\Config
+	 * @var array
 	 */
 	private $options = [
 		'use_ip' => false,
@@ -86,8 +86,7 @@ final class Provider implements ProviderInterface, CacheAware, HttpClientAware, 
 	/**
 	 * Create this Provider
 	 *
-	 * @param Config $config
-	 * @param Toolkit $toolkit
+	 * @param array $options
 	 * @return self
 	 */
 	private function __construct(array $options)

--- a/src/Provider/Youtube/VideoInfo.php
+++ b/src/Provider/Youtube/VideoInfo.php
@@ -23,7 +23,7 @@ namespace YoutubeDownloader\Provider\Youtube;
 use YoutubeDownloader\Cache\Cache;
 use YoutubeDownloader\Cache\CacheAware;
 use YoutubeDownloader\Cache\CacheAwareTrait;
-use YoutubeDownloader\Config;
+use YoutubeDownloader\Config\Config;
 use YoutubeDownloader\Http\HttpClientAware;
 use YoutubeDownloader\Http\HttpClientAwareTrait;
 use YoutubeDownloader\Logger\LoggerAware;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,6 +20,7 @@
 
 namespace YoutubeDownloader;
 
+use YoutubeDownloader\Config\Config;
 use YoutubeDownloader\Container\SimpleContainer;
 
 /**
@@ -48,7 +49,7 @@ class ServiceProvider
 	{
 		$ds = \DIRECTORY_SEPARATOR;
 
-		$container->set('YoutubeDownloader\Config', function($c) {
+		$container->set('YoutubeDownloader\Config\Config', function($c) {
 			return $this->config;
 		});
 
@@ -82,10 +83,10 @@ class ServiceProvider
 				new \YoutubeDownloader\Logger\Handler\NullHandler()
 			);
 
-			if ( $c->get('YoutubeDownloader\Config')->get('debug') === true )
+			if ( $c->get('YoutubeDownloader\Config\Config')->get('debug') === true )
 			{
 				# code...
-				$now = new \DateTime('now', new \DateTimeZone($c->get('YoutubeDownloader\Config')->get('default_timezone')));
+				$now = new \DateTime('now', new \DateTimeZone($c->get('YoutubeDownloader\Config\Config')->get('default_timezone')));
 
 				$filepath = sprintf(
 					'%s' . \DIRECTORY_SEPARATOR . '%s',
@@ -130,7 +131,7 @@ class ServiceProvider
 
 		// Create Youtube Provider
 		$container->set('YoutubeDownloader\Provider\Youtube\Provider', function($c) {
-			$config = $c->get('YoutubeDownloader\Config');
+			$config = $c->get('YoutubeDownloader\Config\Config');
 			$toolkit = $c->get('YoutubeDownloader\Toolkit');
 
 			$options = [
@@ -163,7 +164,8 @@ class ServiceProvider
 		});
 
 		// Set aliases for BC
-		$container->set('config', 'YoutubeDownloader\Config');
+		$container->set('YoutubeDownloader\Config', 'YoutubeDownloader\Config\Config');
+		$container->set('config', 'YoutubeDownloader\Config\Config');
 		$container->set('template', 'YoutubeDownloader\Template\Engine');
 		$container->set('controller_factory', 'YoutubeDownloader\Application\ControllerFactory');
 		$container->set('toolkit', 'YoutubeDownloader\Toolkit');

--- a/src/Toolkit.php
+++ b/src/Toolkit.php
@@ -21,6 +21,7 @@
 namespace YoutubeDownloader;
 
 use Exception;
+use YoutubeDownloader\Config\Config;
 use YoutubeDownloader\VideoInfo\VideoInfo;
 
 /**

--- a/tests/Unit/Provider/Youtube/VideoInfoTest.php
+++ b/tests/Unit/Provider/Youtube/VideoInfoTest.php
@@ -29,7 +29,7 @@ class VideoInfoTest extends \YoutubeDownloader\Tests\Fixture\TestCase
 	 */
 	public function createFromStringWithConfig()
 	{
-		$config = $this->createMock('\\YoutubeDownloader\\Config');
+		$config = $this->createMock('\\YoutubeDownloader\\Config\\Config');
 
 		$video_info = VideoInfo::createFromStringWithConfig('', $config);
 


### PR DESCRIPTION
## WIP
 
This PR rewrites the configuration file and the Config class. The point of this PR is an easier format for non-technical user because the line

```$config['enable_youtube_decipher_signature'] = false;```

is easier to set than the current version:
```
return [
    'enable_youtube_decipher_signature' => true,
];
```

The new Config class has also a built-in transformation so we can modify the configuration but can keep care of the existing user configurations. We can also track the deprecated configuration in the custom.php and notify the user about the changes.