### PR TITLE
Add alternative video info url for age restricted videos

### DIFF
--- a/src/Provider/Youtube/Provider.php
+++ b/src/Provider/Youtube/Provider.php
@@ -133,6 +133,7 @@ final class Provider implements ProviderInterface, CacheAware, HttpClientAware, 
         /* First get the video info page for this video id */
         // $my_video_info = 'http://www.youtube.com/get_video_info?&video_id='. $input;
         // thanks to amit kumar @ bloggertale.com for sharing the fix
+      
         $video_info_url = 'http://www.youtube.com/get_video_info?&video_id=' . $input . '&asv=3&el=detailpage&hl=en_US';
 
         $request = $this->getHttpClient()->createRequest(
@@ -147,6 +148,16 @@ final class Provider implements ProviderInterface, CacheAware, HttpClientAware, 
         }
 
         $response = $this->getHttpClient()->send($request, $options);
+
+        /* Try alternative URL if the status is fail */
+        if (strpos($response->getBodyAsString(), 'status=fail') !== false) {
+            $video_info_url = 'http://www.youtube.com/get_video_info?&video_id=' . $input . '&asv=3&hl=en_US';
+            $request = $this->getHttpClient()->createRequest(
+                'GET',
+                $video_info_url
+            );
+            $response = $this->getHttpClient()->send($request, $options);
+        }
 
         /* TODO: Check response for status code and Content-Type */
         $video_info = VideoInfo::createFromStringWithOptions(

--- a/tests/Unit/Provider/Youtube/ProviderTest.php
+++ b/tests/Unit/Provider/Youtube/ProviderTest.php
@@ -67,6 +67,11 @@ class ProviderTest extends \YoutubeDownloader\Tests\Fixture\TestCase
             ['http://m.youtube.com/?feature=player_embedded&v=dQw4w9WgXcQ', true],
             ['http://m.youtube.com/v/dQw4w9WgXcQ?fs=1&hl=en_US', true],
             ['https://m.youtube-nocookie.com/embed/dQw4w9WgXcQ', true],
+            //test case for age restrictions (id: owUZUdyRVcQ)
+            ['http://youtu.be/owUZUdyRVcQ', true],
+            ['http://www.youtube.com/embed/owUZUdyRVcQ', true],
+            ['http://www.youtube.com/watch?v=owUZUdyRVcQ', true],
+            ['http://www.youtube.com/?v=owUZUdyRVcQ', true],
         ];
     }
 }


### PR DESCRIPTION
<!--

All new PHP code should have tests to ensure against regressions

Please note that you contributing to an open source project. By contributing to this project:

- you put your code under the [GPL2 license](https://github.com/jeckman/YouTube-Downloader/blob/master/LICENSE)
- you assure that you have the permission to put your code under the [GPL2 license](https://github.com/jeckman/YouTube-Downloader/blob/master/LICENSE)

-->

This PR fixes the handling of age restricted videos by making a request to another video info url if the normal one comes back with an error.

This should resolve #293 and allow age restricted videos like https://www.youtube.com/watch?v=owUZUdyRVcQ to run correctly.

As an example, http://www.youtube.com/get_video_info?&video_id=owUZUdyRVcQ&asv=3&el=detailpage&hl=en_US returns `status=fail&reason=Sign+in+to+confirm+your+age&errordetail=1&errorcode=150`

while the alternative url https://www.youtube.com/get_video_info?&video_id=owUZUdyRVcQ&asv=3&hl=en_US returns a valid response with no errors.


> 