### PR TITLE
Fix Youtube Provider test

### DIFF
--- a/tests/Unit/Provider/Youtube/ProviderTest.php
+++ b/tests/Unit/Provider/Youtube/ProviderTest.php
@@ -35,7 +35,7 @@ class ProviderTest extends \YoutubeDownloader\Tests\Fixture\TestCase
     {
         $provider = Provider::createFromOptions([]);
 
-        $this->assertSame($expected, $provider->provides($expected));
+        $this->assertSame($expected, $provider->provides($str));
     }
 
     /**


### PR DESCRIPTION
This Youtube Provider tests are testing `$provider->provides()` with `$expected` instead of `$str`. This PR fixes the tests.