### PR TITLE
Fix Decipher dictionary was not found error when javascipt use bracke…

### DIFF
--- a/src/Provider/Youtube/SignatureDecipher.php
+++ b/src/Provider/Youtube/SignatureDecipher.php
@@ -190,7 +190,13 @@ class SignatureDecipher
 
         $deciphers = explode('(a', $decipherPatterns);
         for ($i=0; $i < count($deciphers); $i++) {
-            $deciphers[$i] = explode('.', explode(';', $deciphers[$i])[1])[0];
+            $z = explode(';', $deciphers[$i], 2)[1];
+            if (strpos($z,'[')!==false) {
+                $deciphers[$i] = explode('[', $z)[0];
+            }
+            else {
+                $deciphers[$i] = explode('.', $z)[0];
+            }
 
             if (count(explode($deciphers[$i], $decipherPatterns))>=2) {
                 // This object was most called, that's mean this is the deciphers
@@ -222,6 +228,8 @@ class SignatureDecipher
 
         // Convert pattern to array
         $decipherPatterns = str_replace($deciphersObjectVar . '.', '', $decipherPatterns);
+        $decipherPatterns = str_replace($deciphersObjectVar . '[', '', $decipherPatterns);
+        $decipherPatterns = str_replace('](a,', '->(', $decipherPatterns);
         $decipherPatterns = str_replace('(a,', '->(', $decipherPatterns);
         $decipherPatterns = explode(';', explode('){', $decipherPatterns)[1]);
 


### PR DESCRIPTION
…t notation in $decipherPatterns like in

a){a=a.split("");VK.BH(a,2);VK.xa(a,13);VK.BH(a,1);VK["do"](a,37);VK.BH(a,1);VK.xa(a,69);VK["do"](a,36);return a.join("")

Seen and fixed on the video https://youtu.be/fs8RUFS18g0
<!--

All new PHP code should have tests to ensure against regressions

Please note that you contributing to an open source project. By contributing to this project:

- you put your code under the [GPL2 license](https://github.com/jeckman/YouTube-Downloader/blob/master/LICENSE)
- you assure that you have the permission to put your code under the [GPL2 license](https://github.com/jeckman/YouTube-Downloader/blob/master/LICENSE)

-->
