### PR TITLE
Solve #364 (Always download via proxy)

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -40,7 +40,7 @@ return [
     /*
      * Video Download Link Configuration
      * 'direct' => show only direct download link
-     * 'proxy'  => show only by proxy download link
+     * 'proxy'  => show only by proxy download link, this will also force the get video command to download through the proxy (ex: getvideo.mp4?videoid=GkvvH8pBoTg&format=ipad)
      * 'both'   => show both direct and by proxy download links
      */
     'VideoLinkMode' => 'both',

--- a/src/Application/ResultController.php
+++ b/src/Application/ResultController.php
@@ -85,7 +85,7 @@ class ResultController extends ControllerAbstract
              * Thanks to the python based youtube-dl for info on the formats
              *   							http://rg3.github.com/youtube-dl/
              */
-            if (!empty($_GET['proxy']) && $_GET['proxy'] !== false) {
+            if (!empty($_GET['proxy']) && $_GET['proxy'] !== false || $config->get('VideoLinkMode') === 'proxy') {
                 $best_format = $this->getFullInfoByFormat($video_info, $_GET['format']);
             
                 $proxylink = 'download.php?mime=' . $best_format->getType()


### PR DESCRIPTION
With this change you can set `VideoLinkMode` to `proxy` to have the `getvideo.mp4?videoid=GkvvH8pBoTg&format=ipad` download it through the proxy URL 

I'm assuming this is what it meant, but tbh I didn't dig into it much.
<!--

All new PHP code should have tests to ensure against regressions

Please note that you contributing to an open source project. By contributing to this project:

- you put your code under the [GPL2 license](https://github.com/jeckman/YouTube-Downloader/blob/master/LICENSE)
- you assure that you have the permission to put your code under the [GPL2 license](https://github.com/jeckman/YouTube-Downloader/blob/master/LICENSE)

-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jeckman/youtube-downloader/366)
<!-- Reviewable:end -->
