### PR TITLE
Fix 'No format stream map found' issue (421)

### DIFF
--- a/src/Provider/Youtube/Provider.php
+++ b/src/Provider/Youtube/Provider.php
@@ -135,12 +135,7 @@ final class Provider implements ProviderInterface, CacheAware, HttpClientAware, 
         // thanks to amit kumar @ bloggertale.com for sharing the fix
 		
 		//This URL *should* allow age restricted videos and regular videos to download
-        $video_info_url = 'https://www.youtube.com/get_video_info?&video_id=' . $input . '&asv=3&hl=en_US';
-
-        $request = $this->getHttpClient()->createFullRequest(
-            'GET',
-            $video_info_url
-        );
+        //$video_info_url = 'https://www.youtube.com/get_video_info?&video_id=' . $input . '&asv=3&hl=en_US';
 
         $options = ['curl' => []];
 
@@ -148,22 +143,18 @@ final class Provider implements ProviderInterface, CacheAware, HttpClientAware, 
             $options['curl'][CURLOPT_INTERFACE] = $this->options['use_ip'];
         }
 
+        $video_info_url = 'https://www.youtube.com/get_video_info?&video_id=' . $input . '&asv=3&el=detailpage&hl=en_US';
+        $request = $this->getHttpClient()->createFullRequest(
+            'GET',
+            $video_info_url
+        );
         $response = $this->getHttpClient()->send($request, $options);
-		
-		//But just incase it doesn't, we can fallback to the old URL.
-		if (strpos($response->getBody()->__toString(), 'status=fail') !== false) {
-			$video_info_url = 'https://www.youtube.com/get_video_info?&video_id=' . $input . '&asv=3&el=detailpage&hl=en_US';
-            $request = $this->getHttpClient()->createFullRequest(
-                'GET',
-                $video_info_url
-            );
-            $response = $this->getHttpClient()->send($request, $options);
-        }
 		
         /* TODO: Check response for status code and Content-Type */
         $video_info = VideoInfo::createFromStringWithOptions(
             $response->getBody()->__toString(),
-            $this->options
+            $this->options,
+            $input
         );
 
         if ($video_info instanceof CacheAware) {

--- a/src/Provider/Youtube/VideoInfo.php
+++ b/src/Provider/Youtube/VideoInfo.php
@@ -160,15 +160,15 @@ class VideoInfo implements VideoInfoInterface, CacheAware, HttpClientAware, Logg
     use LoggerAwareTrait;
 
     /**
+     *
      * Creates a VideoInfo from string with an options array
      *
-     * @param string $video_id
-     * @param array  $options
-     * @param mixed  $string
-     *
+     * @param $string
+     * @param array $options
+     * @param null $video_id
      * @return VideoInfo
      */
-    public static function createFromStringWithOptions($string, array $options, $video_id)
+    public static function createFromStringWithOptions($string, array $options, $video_id = null)
     {
         $default = [
             'decipher_signature' => false,
@@ -182,8 +182,10 @@ class VideoInfo implements VideoInfoInterface, CacheAware, HttpClientAware, Logg
 
         parse_str($string, $video_info);
 
-        // $string may not contain video_id, so we append it manually
-        $video_info['video_id'] = $video_id;
+        // $string may not contain video_id, so we should append it manually if we have it beforehand
+        if(empty($video_info['video_id']) && !empty($video_id)) {
+            $video_info['video_id'] = $video_id;
+        }
 
         return new self($video_info, $options);
     }

--- a/src/Provider/Youtube/VideoInfo.php
+++ b/src/Provider/Youtube/VideoInfo.php
@@ -162,13 +162,13 @@ class VideoInfo implements VideoInfoInterface, CacheAware, HttpClientAware, Logg
     /**
      * Creates a VideoInfo from string with an options array
      *
-     * @param string $video_info
+     * @param string $video_id
      * @param array  $options
      * @param mixed  $string
      *
      * @return VideoInfo
      */
-    public static function createFromStringWithOptions($string, array $options)
+    public static function createFromStringWithOptions($string, array $options, $video_id)
     {
         $default = [
             'decipher_signature' => false,
@@ -181,6 +181,9 @@ class VideoInfo implements VideoInfoInterface, CacheAware, HttpClientAware, Logg
         }
 
         parse_str($string, $video_info);
+
+        // $string may not contain video_id, so we append it manually
+        $video_info['video_id'] = $video_id;
 
         return new self($video_info, $options);
     }


### PR DESCRIPTION
Example YouTube video: https://www.youtube.com/watch?v=kXYiU_JCYtU

It used to show **'No format stream map found'** message, now it works fine as long as 'enable_youtube_decipher_signature' is set to true in config.php